### PR TITLE
communities: page reorder

### DIFF
--- a/invenio_communities/templates/communities/index_base.html
+++ b/invenio_communities/templates/communities/index_base.html
@@ -30,6 +30,12 @@
 <div class="row">
 
   <div class="col-xs-12 col-sm-12 col-md-12">
+    <div class="page-header">
+      <h2>
+        <i class="fa fa-group"></i>
+        {{ _("Communities") }} <small>{{ _("created and curated by %(x_name)s users", x_name=config.CFG_SITE_NAME) }}</small>
+      </h2>
+    </div>
     <nav class="navbar navbar-default" role="navigation">
       <div class="navbar-collapse">
         <form action="." method="GET" id="search_form" class="navbar-form" role="form">
@@ -45,10 +51,6 @@
         </form>
       </div>
     </nav>
-    <h1>
-      <i class="fa fa-group"></i>
-      {{ _("Communities") }} <small>{{ _("created and curated by ") + config.CFG_SITE_NAME + _(" users") }}</small>
-    </h1>
   </div>
 
   <div class="col-sm-8 col-md-8">
@@ -124,13 +126,16 @@
             {% if obj %}
               <div class="col-sm-12 col-md-6">
                 <div class="well">
-                  <div class="pull-right" style="margin-top: 10px">
-                    <a href="{{ obj.community_url }}" class="btn btn-info">{{ _('View') }}</a>
-                    {% if obj.id_user == current_user.id %}
-                      <a href="{{ obj.community_provisional_url }}" class="btn btn-info">{{ _('Curate') }}</a>
-                    {% endif %}
-                  </div>
-                  <h4>{{ obj.title }}</h4><br />
+                  <h4>
+                    <div class="pull-right">
+                      &nbsp;
+                      <a href="{{ obj.community_url }}" class="btn btn-info">{{ _('View') }}</a>
+                      {% if obj.id_user == current_user.id %}
+                        <a href="{{ obj.community_provisional_url }}" class="btn btn-info">{{ _('Curate') }}</a>
+                      {% endif %}
+                    </div>
+                    {{ obj.title }}
+                  </h4><br />
                   <p>{{ obj.description|striptags|truncate }}</p>
                   <small class="text-muted">Curated by: {{ obj.owner.nickname }}</small>
                 </div>

--- a/invenio_communities/templates/communities/mycommunities_base.html
+++ b/invenio_communities/templates/communities/mycommunities_base.html
@@ -1,6 +1,6 @@
 {#
 # This file is part of Invenio.
-# Copyright (C) 2013, 2014 CERN.
+# Copyright (C) 2013, 2014, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -19,23 +19,27 @@
 
 <div class="well">
 {% if current_user.is_authenticated() %}
-<a href="{{url_for('.new')}}" class="btn btn-primary pull-right"><i class="icon-plus-sign"></i> New</a>
 {% if mycommunities %}
-<h2>My communities</h2>
+<h2>
+  {{ _('My communities') }}
+  <div class="pull-right">
+    &nbsp;<a href="{{url_for('.new')}}" class="btn btn-primary"><i class="icon-plus-sign"></i> {{ _('New') }}</a>
+  </div>
+</h2>
 <table class="table table-striped">
 {% for obj in mycommunities %}
 <tr>
-    <td><a href="{{url_for('.edit', community_id=obj.id)}}">{{obj.title if obj.title else 'Untitled'}}</a><br ><small class="muted">Identifier: {{obj.id}}</small></td>
+    <td><a href="{{url_for('.edit', community_id=obj.id)}}">{{obj.title if obj.title else 'Untitled'}}</a><br ><small class="muted">{{ _('Identifier') }}: {{obj.id}}</small></td>
     <td>
         <div class="btn-group">
           <a class="btn btn-default dropdown-toggle btn-xs" data-toggle="dropdown" href="#">
-            Actions
+            {{ _('Actions') }}
             <span class="caret"></span>
           </a>
           <ul class="dropdown-menu">
-            <li><a href="{{obj.community_url}}"><i class="icon-eye-open"></i> View</a></li>
-            <li><a href="{{obj.community_provisional_url}}"><i class="icon-check"></i> Curate</a></li>
-            <li><a href="{{url_for('.edit', community_id=obj.id)}}"><i class="icon-pencil"></i> Edit</a></li>
+            <li><a href="{{obj.community_url}}"><i class="icon-eye-open"></i> {{ _('View') }}</a></li>
+            <li><a href="{{obj.community_provisional_url}}"><i class="icon-check"></i> {{ _('Curate') }}</a></li>
+            <li><a href="{{url_for('.edit', community_id=obj.id)}}"><i class="icon-pencil"></i> {{ _('Edit') }}</a></li>
           </ul>
         </div>
     </td>
@@ -43,24 +47,34 @@
 {% endfor %}
 </table>
 {% else %}
-<p class="muted">You currently have no community collections.</p>
+<p class="muted">{{ _('You currently have no community collections.') }}</p>
 
-<h4><strong>Want your own community?</strong></h4>
-<p>It's easy. Just click the button to get started. </p>
+<h4>
+  <div class="pull-right">
+    &nbsp;<a href="{{url_for('.new')}}" class="btn btn-primary"><i class="icon-plus-sign"></i> {{ _('New') }}</a>
+  </div>
+  <strong>{{ _('Want your own community?') }}</strong>
+</h4>
+<p>{{ _('It\'s easy. Just click the button to get started.') }}</p>
 <ul>
-    <li><strong>Curate</strong> &mdash; accept/reject what goes in your community collection.</li>
-    <li><strong>Export</strong> &mdash; your community collection is automatically exported via OAI-PMH</li>
-    <li><strong>Upload</strong> &mdash; get custom upload link to send to people</li>
+    <li><strong>{{ _('Curate') }}</strong> &mdash; {{ _('accept/reject what goes in your community collection.') }}</li>
+    <li><strong>{{ _('Export') }}</strong> &mdash; {{ _('your community collection is automatically exported via OAI-PMH') }}</li>
+    <li><strong>{{ _('Upload') }}</strong> &mdash; {{ _('get custom upload link to send to people') }}</li>
 </ul>
 {% endif %}
 {% else %}
-<a href="/youraccount/register" class="btn btn-warning btn-large signup pull-right">Sign Up</a>
-<h4><strong>Want your own community?</strong></h4>
-<p>It's easy. Just sign-up and create a new community. </p>
+
+<h4>
+  <div class="pull-right">
+    &nbsp;<a href="/youraccount/register" class="btn btn-warning btn-large signup">{{ _('Sign Up') }}</a>
+  </div>
+  <strong>{{ _('Want your own community?') }}</strong>
+</h4>
+<p>{{ _('It\'s easy. Just click the button to get started.') }}</p>
 <ul>
-    <li><strong>Curate</strong> &mdash; accept/reject what goes in your community collection.</li>
-    <li><strong>Export</strong> &mdash; your community collection is automatically exported via OAI-PMH</li>
-    <li><strong>Upload</strong> &mdash; get custom upload link to send to people</li>
+    <li><strong>{{ _('Curate') }}</strong> &mdash; {{ _('accept/reject what goes in your community collection.') }}</li>
+    <li><strong>{{ _('Export') }}</strong> &mdash; {{ _('your community collection is automatically exported via OAI-PMH') }}</li>
+    <li><strong>{{ _('Upload') }}</strong> &mdash; {{ _('get custom upload link to send to people') }}</li>
 </ul>
 {% endif %}
 </div>


### PR DESCRIPTION
* Places heading before search field. This is more logical and improves
  flow. Downgrades heading to level 2, because it is not the page title
  (which is Invenio) and it makes longer text better readable on
  smaller screens.

* Readjusts construction of title + button of listed communities, so
  long titles do not flow into the buttons. Removes hardcoded style
  values as well.

* Aligns 'My Communities'>{'New','Sign Up'] button with the heading.

* Extracts static `communitiy.css` from template.

Signed-off-by: Marco Neumann <marco@crepererum.net>

Rebased against: `master`
Extracted from inveniosoftware/invenio#3069