### PR TITLE
global: fix import of invenio_upgrader

### DIFF
--- a/invenio_communities/upgrades/communities_2014_03_07_ranker.py
+++ b/invenio_communities/upgrades/communities_2014_03_07_ranker.py
@@ -19,7 +19,7 @@
 
 from sqlalchemy import *
 from invenio.ext.sqlalchemy import db
-from invenio.modules.upgrader.api import op
+from invenio_upgrader.api import op
 
 depends_on = []
 

--- a/invenio_communities/upgrades/communities_2014_10_17_featured_communities.py
+++ b/invenio_communities/upgrades/communities_2014_10_17_featured_communities.py
@@ -20,7 +20,7 @@
 """communityFEATURED table addition."""
 
 from invenio.ext.sqlalchemy import db
-from invenio.modules.upgrader.api import op
+from invenio_upgrader.api import op
 
 depends_on = [u'communities_2014_03_07_ranker']
 

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -27,3 +27,5 @@
 #
 #     -e git+git://github.com/mitsuhiko/werkzeug.git#egg=Werkzeug
 #     -e git+git://github.com/mitsuhiko/jinja2.git#egg=Jinja2
+
+-e git+git://github.com/inveniosoftware/invenio-upgrader.git#egg=invenio-upgrader

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ requirements = [
     'SQLAlchemy>=1.0',
     'wtforms-alchemy>=0.13.1',
     'WTForms>=2.0.1',
+    'invenio-upgrader>=0.1.0',
 ]
 
 test_requirements = [


### PR DESCRIPTION
* FIX Fixes import of invenio_upgrader in the past upgrade recipes
  following its separation into standalone package.

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>