### PR TITLE
installation: fix invenio_access import

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -38,5 +38,6 @@ Contact us at `info@invenio-software.org
 - Lars Holm Nielsen <lars.holm.nielsen@cern.ch>
 - Leonardo Rossi <leonardo.r@cern.ch>
 - Marco Neumann <marco@crepererum.net>
+- Sami Hiltunen <sami.mikael.hiltunen@cern.ch>
 - Tibor Simko <tibor.simko@cern.ch>
 - Yoan Blanc <yoan.blanc@cern.ch>

--- a/invenio_communities/models.py
+++ b/invenio_communities/models.py
@@ -53,7 +53,7 @@ from invenio.config import CFG_SITE_LANG
 from invenio.ext.sqlalchemy import db
 from invenio.ext.template import render_template_to_string
 from invenio.legacy.bibrecord import record_add_field
-from invenio.modules.access.models import \
+from invenio_access.models import \
     AccACTION, AccARGUMENT, \
     AccAuthorization, AccROLE, UserAccROLE
 from invenio.modules.accounts.models import User

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -28,4 +28,5 @@
 #     -e git+git://github.com/mitsuhiko/werkzeug.git#egg=Werkzeug
 #     -e git+git://github.com/mitsuhiko/jinja2.git#egg=Jinja2
 
+-e git+git://github.com/inveniosoftware/invenio-access.git#egg=invenio-access
 -e git+git://github.com/inveniosoftware/invenio-upgrader.git#egg=invenio-upgrader

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ requirements = [
     'SQLAlchemy>=1.0',
     'wtforms-alchemy>=0.13.1',
     'WTForms>=2.0.1',
+    'invenio-access>=0.1.0',
     'invenio-upgrader>=0.1.0',
 ]
 
@@ -59,6 +60,7 @@ test_requirements = [
 
 
 class PyTest(TestCommand):
+
     """PyTest Test."""
 
     user_options = [('pytest-args=', 'a', "Arguments to pass to py.test")]


### PR DESCRIPTION
* Adds missing `invenio_access` dependency and amends past upgrade
  recipes following its separation into standalone package.

Signed-off-by: Sami Hiltunen <sami.mikael.hiltunen@cern.ch>