### PR TITLE
installation: fix invenio_base imports

### DIFF
--- a/invenio_communities/bundles.py
+++ b/invenio_communities/bundles.py
@@ -21,7 +21,7 @@
 
 from __future__ import unicode_literals
 
-from invenio.base.bundles import invenio as _i, jquery as _j
+from invenio_base.bundles import invenio as _i, jquery as _j
 from invenio.ext.assets import Bundle, RequireJSFilter
 
 

--- a/invenio_communities/forms.py
+++ b/invenio_communities/forms.py
@@ -21,7 +21,7 @@
 
 from __future__ import absolute_import
 
-from invenio.base.i18n import _
+from invenio_base.i18n import _
 from invenio.utils.forms import InvenioBaseForm, InvenioForm as Form
 
 from wtforms import HiddenField, StringField, TextAreaField, validators

--- a/invenio_communities/models.py
+++ b/invenio_communities/models.py
@@ -48,7 +48,7 @@ from datetime import datetime
 
 from flask import url_for
 
-from invenio.base.globals import cfg
+from invenio_base.globals import cfg
 from invenio.config import CFG_SITE_LANG
 from invenio.ext.sqlalchemy import db
 from invenio.ext.template import render_template_to_string

--- a/invenio_communities/tasks.py
+++ b/invenio_communities/tasks.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2014 CERN.
+# Copyright (C) 2014, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -25,7 +25,7 @@ from invenio.modules.collections.models import Collection
 from celery.task.base import PeriodicTask
 
 from .models import Community
-from invenio.base.globals import cfg
+from invenio_base.globals import cfg
 
 
 class RankingTask(PeriodicTask):

--- a/invenio_communities/views.py
+++ b/invenio_communities/views.py
@@ -30,9 +30,9 @@ from flask_login import current_user, login_required
 
 from flask_menu import register_menu
 
-from invenio.base.decorators import wash_arguments
-from invenio.base.globals import cfg
-from invenio.base.i18n import _
+from invenio_base.decorators import wash_arguments
+from invenio_base.globals import cfg
+from invenio_base.i18n import _
 from invenio.ext.cache import cache
 from invenio.ext.principal import permission_required
 from invenio.ext.sqlalchemy import db

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -29,4 +29,5 @@
 #     -e git+git://github.com/mitsuhiko/jinja2.git#egg=Jinja2
 
 -e git+git://github.com/inveniosoftware/invenio-access.git#egg=invenio-access
+-e git+git://github.com/inveniosoftware/invenio-base.git#egg=invenio-base
 -e git+git://github.com/inveniosoftware/invenio-upgrader.git#egg=invenio-upgrader

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ requirements = [
     'wtforms-alchemy>=0.13.1',
     'WTForms>=2.0.1',
     'invenio-access>=0.1.0',
+    'invenio-base>=0.2.1',
     'invenio-upgrader>=0.1.0',
 ]
 

--- a/tests/test_communities.py
+++ b/tests/test_communities.py
@@ -25,7 +25,7 @@ import shutil
 from datetime import datetime, timedelta
 from mock import PropertyMock, patch
 
-from invenio.base.wrappers import lazy_import
+from invenio_base.wrappers import lazy_import
 from six import iteritems
 from invenio.testsuite import InvenioTestCase, \
     make_test_suite, \

--- a/tests/test_featured_community.py
+++ b/tests/test_featured_community.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2014 CERN.
+# Copyright (C) 2014, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -21,7 +21,7 @@
 
 import datetime
 
-from invenio.base.wrappers import lazy_import
+from invenio_base.wrappers import lazy_import
 from invenio.testsuite import InvenioTestCase, make_test_suite, run_test_suite
 from invenio.ext.sqlalchemy import db
 


### PR DESCRIPTION
* FIX Adds missing `invenio_base` dependency and amends past
  upgrade recipes following its separation into standalone package.

Signed-off-by: Sami Hiltunen <sami.mikael.hiltunen@cern.ch>