### PR TITLE
tests: fix incompatibility with pytest>=2.8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,9 +35,9 @@ cache:
   - pip
 
 env:
-  - REQUIREMENTS=lowest REXTRAS=docs,test
-  - REQUIREMENTS=release REXTRAS=docs,test
-  - REQUIREMENTS=devel REXTRAS=docs,test
+  - REQUIREMENTS=lowest REXTRAS=docs,tests
+  - REQUIREMENTS=release REXTRAS=docs,tests
+  - REQUIREMENTS=devel REXTRAS=docs,tests
 
 python:
   - "2.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ before_install:
   - "sudo apt-get update"
   - "sudo apt-get install python-dev"
   - "travis_retry pip install --upgrade pip"
-  - "travis_retry pip install check-manifest mock twine wheel"
+  - "travis_retry pip install check-manifest mock twine wheel coveralls"
   - "python requirements.py --extras=$REXTRAS --level=min > .travis-lowest-requirements.txt"
   - "python requirements.py --extras=$REXTRAS --level=pypi > .travis-release-requirements.txt"
   - "python requirements.py --extras=$REXTRAS --level=dev > .travis-devel-requirements.txt"

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ before_install:
   - "sudo apt-get update"
   - "sudo apt-get install python-dev"
   - "travis_retry pip install --upgrade pip"
-  - "travis_retry pip install mock twine wheel"
+  - "travis_retry pip install check-manifest mock twine wheel"
   - "python requirements.py --extras=$REXTRAS --level=min > .travis-lowest-requirements.txt"
   - "python requirements.py --extras=$REXTRAS --level=pypi > .travis-release-requirements.txt"
   - "python requirements.py --extras=$REXTRAS --level=dev > .travis-devel-requirements.txt"
@@ -62,6 +62,7 @@ before_script:
   - "inveniomanage database create --quiet || echo ':('"
 
 script:
+  - "check-manifest --ignore .travis-\\*-requirements.txt"
   - "sphinx-build -qnN docs docs/_build/html"
   - "python setup.py test"
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -23,6 +23,6 @@
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
 [pytest]
-addopts = --clearcache --pep8 --ignore=docs --cov=invenio_communities --cov-report=term-missing
+addopts = --pep8 --ignore=docs --cov=invenio_communities --cov-report=term-missing
 pep8ignore =
     tests/* ALL

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -21,12 +21,6 @@
 # In applying this license, CERN does not
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
-#
-# TODO: Add development versions of some important dependencies here to get a
-#       warning when there are breaking upstream changes, e.g.:
-#
-#     -e git+git://github.com/mitsuhiko/werkzeug.git#egg=Werkzeug
-#     -e git+git://github.com/mitsuhiko/jinja2.git#egg=Jinja2
 
 -e git+git://github.com/inveniosoftware/invenio-access.git#egg=invenio-access
 -e git+git://github.com/inveniosoftware/invenio-accounts.git#egg=invenio-accounts

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,7 @@ test_requirements = [
     'pytest-cov>=2.1.0',
     'pytest-pep8>=1.0.6',
     'pytest>=2.8.0',
+    'invenio-testing>=0.1.1',
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -59,12 +59,12 @@ requirements = [
 ]
 
 test_requirements = [
+    'coverage>=4.0.0',
     'Flask-Testing>=0.4.1',
-    'coverage>=3.7.1',
     'invenio-testing>=0.1.0',
-    'pytest-cov>=1.8.1',
+    'pytest-cov>=2.1.0',
     'pytest-pep8>=1.0.6',
-    'pytest>=2.7.0',
+    'pytest>=2.8.0',
 ]
 
 
@@ -96,9 +96,6 @@ class PyTest(TestCommand):
         """Run tests."""
         # import here, cause outside the eggs aren't loaded
         import pytest
-        import _pytest.config
-        pm = _pytest.config.get_plugin_manager()
-        pm.consider_setuptools_entrypoints()
         errno = pytest.main(self.pytest_args)
         sys.exit(errno)
 

--- a/tests/test_communities.py
+++ b/tests/test_communities.py
@@ -21,20 +21,24 @@
 
 import os
 import shutil
-
 from datetime import datetime, timedelta
-from mock import PropertyMock, patch
 
-from invenio_base.wrappers import lazy_import
-from six import iteritems
-from invenio_testing import InvenioTestCase
-from invenio_ext.sqlalchemy import db
 from flask_login import current_user
 
+from invenio_base.wrappers import lazy_import
+
 from invenio_communities.config import COMMUNITIES_ID_PREFIX, \
-    COMMUNITIES_ID_PREFIX_PROVISIONAL, \
-    COMMUNITIES_OUTPUTFORMAT, \
+    COMMUNITIES_ID_PREFIX_PROVISIONAL, COMMUNITIES_OUTPUTFORMAT, \
     COMMUNITIES_OUTPUTFORMAT_PROVISIONAL
+
+from invenio_ext.sqlalchemy import db
+
+from invenio_testing import InvenioTestCase
+
+from mock import PropertyMock, patch
+
+from six import iteritems
+
 
 Community = lazy_import('invenio_communities.models:Community')
 Collection = lazy_import('invenio_collections.models:Collection')
@@ -92,7 +96,8 @@ class CommunityModelTest(InvenioTestCase):
         """communities - checks if portalboxes were created for community"""
         c = self._find_community_info()
         self.assertTrue(len(c.collection.portalboxes[0].portalbox.body) > 0)
-        self.assertTrue(len(c.collection_provisional.portalboxes[0].portalbox.body) > 0)
+        self.assertTrue(
+            len(c.collection_provisional.portalboxes[0].portalbox.body) > 0)
 
     def test_5_delete_community(self):
         """communities - delete community"""
@@ -121,7 +126,7 @@ class CommunityRankerTest(InvenioTestCase):
             Collection has number of records set to 1.
         """
         c = Community()
-        for key,value in iteritems(options):
+        for key, value in iteritems(options):
             setattr(c, key, value)
         # add a collection with "one" record
         coll = Collection()
@@ -132,7 +137,7 @@ class CommunityRankerTest(InvenioTestCase):
         """communities - test community rank basic"""
         c = self._create_comunity({'id': self.test_name,
                                    'id_user': 1,
-                                   'last_record_accepted': datetime.now()-timedelta(days=100),
+                                   'last_record_accepted': datetime.now() - timedelta(days=100),
                                    'fixed_points': 0})
         with patch('invenio_collections.models.Collection.nbrecs',
                    new_callable=PropertyMock) as mock_nbrecs:

--- a/tests/test_featured_community.py
+++ b/tests/test_featured_community.py
@@ -22,8 +22,10 @@
 import datetime
 
 from invenio_base.wrappers import lazy_import
-from invenio_testing import InvenioTestCase, make_test_suite, run_test_suite
+
 from invenio_ext.sqlalchemy import db
+
+from invenio_testing import InvenioTestCase
 
 FeaturedCommunity = lazy_import('invenio_communities.models:'
                                 'FeaturedCommunity')

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2013, 2014 CERN.
+# Copyright (C) 2013, 2014, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -20,7 +20,8 @@
 """Tests for communities views."""
 
 from flask import url_for
-from invenio_testing import InvenioTestCase, make_test_suite, run_test_suite
+
+from invenio_testing import InvenioTestCase
 
 
 class CommunitiesViewTest(InvenioTestCase):


### PR DESCRIPTION
* FIX Removes calls to PluginManager
  consider_setuptools_entrypoints() removed in PyTest 2.8.0.

Signed-off-by: Sami Hiltunen <sami.mikael.hiltunen@cern.ch>