### PR TITLE
rest: addition of etag to community details

### DIFF
--- a/invenio_communities/models.py
+++ b/invenio_communities/models.py
@@ -26,6 +26,7 @@
 
 from __future__ import absolute_import, print_function
 
+import hashlib
 from datetime import datetime
 
 from flask import current_app, url_for
@@ -422,6 +423,16 @@ class Community(db.Model, Timestamp):
             'invenio_oaiserver.response',
             verb='ListRecords',
             metadataPrefix='oai_dc', set=self.oaiset_spec, _external=True)
+
+    @property
+    def version_id(self):
+        """Return the version of the community.
+
+        :returns: hash which encodes the community id and its las update.
+        :rtype: str
+        """
+        return hashlib.sha1('{0}__{1}'.format(
+            self.id, self.updated).encode('utf-8')).hexdigest()
 
 
 class FeaturedCommunity(db.Model, Timestamp):

--- a/invenio_communities/views/api.py
+++ b/invenio_communities/views/api.py
@@ -177,9 +177,12 @@ class CommunityDetailsResource(ContentNegotiatedMethodView):
         community = Community.get(community_id)
         if not community:
             abort(404)
-        return self.make_response(
-                community, links_item_factory=default_links_item_factory)
-
+        etag = community.version_id
+        self.check_etag(etag)
+        response = self.make_response(
+            community, links_item_factory=default_links_item_factory)
+        response.set_etag(etag)
+        return response
 
 serializers = {'application/json': community_response}
 

--- a/tests/test_invenio_communities.py
+++ b/tests/test_invenio_communities.py
@@ -299,3 +299,18 @@ def test_communities_rest_get_details(app, db, communities):
                     'html': 'http://inveniosoftware.org/communities/comm1/',
                 },
         )
+
+
+def test_communities_rest_etag(app, communities):
+    """Test the OAI-PMH Sets creation."""
+    with app.test_client() as client:
+        # The first response should return the data with result code 200
+        response = client.get('/api/communities/comm1')
+        assert response.status_code == 200
+        assert response.get_data(as_text=True) != ''
+
+        # The second response is empty and the result code is 304
+        response = client.get('/api/communities/comm1', headers=(
+            ('If-None-Match', response.headers.get('ETag')),))
+        assert response.status_code == 304
+        assert response.get_data(as_text=True) == ''


### PR DESCRIPTION
* Adds the etag header to the details of each community. (closes #38)

Signed-off-by: Javier Delgado <javier.delgado.fernandez@cern.ch>