### PR TITLE
global: communities accept/remove bugfix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ tests_require = [
     'coverage>=4.0',
     'Flask-CLI>=0.2.1',
     'invenio-mail>=1.0.0a3',
-    'invenio-oaiserver>=1.0.0a2',
+    'invenio-oaiserver>=1.0.0a8',
     'isort>=4.2.2',
     'mock>=1.3.0',
     'pydocstyle>=1.0.0',
@@ -59,7 +59,7 @@ extras_require = {
         'Flask-Mail>=0.9.1',
     ],
     'oai': [
-        'invenio-oaiserver>=1.0.0a2',
+        'invenio-oaiserver>=1.0.0a8',
     ],
     'tests': tests_require,
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -133,3 +133,12 @@ def communities(app, db, user):
     comm1 = Community.create(community_id='comm2', user_id=user1.id, title='A')
     comm2 = Community.create(community_id='oth3', user_id=user1.id)
     return comm0, comm1, comm2
+
+
+@pytest.yield_fixture()
+def disable_request_email(app):
+    """Fixture for disabling request emails."""
+    orig = app.config['COMMUNITIES_MAIL_ENABLED']
+    app.config['COMMUNITIES_MAIL_ENABLED'] = False
+    yield
+    app.config['COMMUNITIES_MAIL_ENABLED'] = orig


### PR DESCRIPTION
* Fixes the issue with accepting and removing communities raising assertion
  errors on external modification of 'communities' key in record.

Signed-off-by: Krzysztof Nowak <k.nowak@cern.ch>