### PR TITLE
models: UUID as community identifier

### DIFF
--- a/invenio_communities/cli.py
+++ b/invenio_communities/cli.py
@@ -57,15 +57,15 @@ def init():
 
 
 @communities.command()
-@click.argument('community_id')
+@click.argument('community_name')
 @click.argument('logo', type=click.File('rb'))
 @with_appcontext
-def addlogo(community_id, logo):
+def addlogo(community_name, logo):
     """Add logo to the community."""
     # Create the bucket
-    c = Community.get(community_id)
+    c = Community.get(community_name=community_name)
     if not c:
-        click.secho('Community {0} does not exist.'.format(community_id),
+        click.secho('Community {0} does not exist.'.format(community_name),
                     fg='red')
         return
     ext = save_and_validate_logo(logo, logo.name, c.id)
@@ -74,13 +74,13 @@ def addlogo(community_id, logo):
 
 
 @communities.command()
-@click.argument('community_id')
+@click.argument('community_name')
 @click.argument('record_id')
 @click.option('-a', '--accept', 'accept', is_flag=True, default=False)
 @with_appcontext
-def request(community_id, record_id, accept):
+def request(community_name, record_id, accept):
     """Request a record acceptance to a community."""
-    c = Community.get(community_id)
+    c = Community.get(community_name=community_name)
     assert c is not None
     record = Record.get_record(record_id)
     if accept:
@@ -94,12 +94,12 @@ def request(community_id, record_id, accept):
 
 
 @communities.command()
-@click.argument('community_id')
+@click.argument('community_name')
 @click.argument('record_id')
 @with_appcontext
-def remove(community_id, record_id):
+def remove(community_name, record_id):
     """Remove a record from community."""
-    c = Community.get(community_id)
+    c = Community.get(community_name=community_name)
     assert c is not None
     c.remove_record(record_id)
     db.session.commit()

--- a/invenio_communities/config.py
+++ b/invenio_communities/config.py
@@ -100,5 +100,5 @@ COMMUNITIES_CURATE_TEMPLATE = "invenio_communities/curate.html"
 COMMUNITIES_SEARCH_TEMPLATE = "invenio_communities/search.html"
 
 COMMUNITIES_URL_COMMUNITY_VIEW = \
-    '{protocol}://{host}/communities/{community_id}/'
+    '{protocol}://{host}/communities/{community_name}/'
 """String pattern to generate the URL for the view of a community."""

--- a/invenio_communities/links.py
+++ b/invenio_communities/links.py
@@ -36,11 +36,11 @@ def default_links_item_factory(community):
             '.communities_item', community_id=community['id'], _external=True),
         html=current_app.config.get(
             'COMMUNITIES_URL_COMMUNITY_VIEW',
-            '{protocol}://{host}/communities/{community_id}/'
+            '{protocol}://{host}/communities/{community_name}/'
         ).format(
             protocol=request.environ['wsgi.url_scheme'],
             host=request.environ['HTTP_HOST'],
-            community_id=community['id']
+            community_name=community['name']
         )
     )
 

--- a/invenio_communities/serializers/schemas/community.py
+++ b/invenio_communities/serializers/schemas/community.py
@@ -35,7 +35,8 @@ from invenio_communities.links import default_links_item_factory, \
 class CommunitySchemaV1(Schema):
     """Schema for a community."""
 
-    id = fields.String()
+    id = fields.UUID()
+    name = fields.String()
     title = fields.String()
     description = fields.String()
     page = fields.String()

--- a/invenio_communities/templates/invenio_communities/curate.html
+++ b/invenio_communities/templates/invenio_communities/curate.html
@@ -59,7 +59,7 @@
 {%- block search_results %}
 <invenio-search-results-provisional
  template="{{ url_for('static', filename=config.COMMUNITIES_JSTEMPLATE_RESULTS_CURATE) }}"
- community-curation-endpoint="{{ url_for('invenio_communities.curate', community_id=community.id) }}">
+ community-curation-endpoint="{{ url_for('invenio_communities.curate', community_name=community.name) }}">
 </invenio-search-results-provisional>
 {%- endblock search_results %}
 

--- a/invenio_communities/templates/invenio_communities/detail.html
+++ b/invenio_communities/templates/invenio_communities/detail.html
@@ -28,7 +28,7 @@
   <div class="row">
     <div class="col-md-8" id="invenio-search">
       <h2>Recent uploads</h2>
-      <form action="{{url_for('.search', community_id=community.id)}}" role="search">
+      <form action="{{url_for('.search', community_name=community.name)}}" role="search">
         <div class="form-group">
           <div class="input-group">
             <input type="text" class="form-control" name="q" placeholder="{{_('Search ') + community.title}}">
@@ -61,8 +61,8 @@
         {%- endblock search_results %}
       </invenio-search>
       {%- endblock search_body %}
-      <p class="text-center"><a class="btn btn-default" href="{{url_for('.search', community_id=community
-      .id)}}">More</a></p>
+      <p class="text-center"><a class="btn btn-default" href="{{url_for('.search', community_name=community
+      .name)}}">More</a></p>
     </div>
     <div class="col-md-4">
       <div class="well">{% include "invenio_communities/portalbox_main.html" %}</div>

--- a/invenio_communities/templates/invenio_communities/index.html
+++ b/invenio_communities/templates/invenio_communities/index.html
@@ -83,7 +83,7 @@
           <div class="ribbon-wrapper-green">
             <div class="ribbon-green">{{ _("Featured") }}</div>
           </div>
-          <a href="{{url_for('.detail', community_id=featured_community.id)}}">
+          <a href="{{url_for('.detail', community_name=featured_community.name)}}">
           <h2>{{ featured_community.title }}</h2>
           </a>
           <div>
@@ -101,9 +101,9 @@
                     <h4>
                       <div class="pull-right">
                         &nbsp;
-                        <a href="{{url_for('.detail', community_id=obj.id)}}" class="btn btn-info">{{ _('View') }}</a>
+                        <a href="{{url_for('.detail', community_name=obj.name)}}" class="btn btn-info">{{ _('View') }}</a>
                         {% if obj.id_user == current_user.id %}
-                          <a href="{{url_for('.curate', community_id=obj.id)}}" class="btn btn-info">{{ _('Curate') }}</a>
+                          <a href="{{url_for('.curate', community_name=obj.name)}}" class="btn btn-info">{{ _('Curate') }}</a>
                         {% endif %}
                       </div>
                       {{ obj.title }}

--- a/invenio_communities/templates/invenio_communities/macros.html
+++ b/invenio_communities/templates/invenio_communities/macros.html
@@ -27,7 +27,7 @@
       <div class="col-md-12">
         <h1>
           {%- if link %}
-          <a href="{{ url_for('.detail', community_id=community.id) }}">{{community.title}}</a>
+          <a href="{{ url_for('.detail', community_name=community.name) }}">{{community.title}}</a>
           {% else %}
           {{community.title}}
           {%- endif %}

--- a/invenio_communities/templates/invenio_communities/mycommunities.html
+++ b/invenio_communities/templates/invenio_communities/mycommunities.html
@@ -34,7 +34,7 @@
   {% for obj in mycommunities %}
     <tr>
       <td>
-        <a href="{{url_for('.edit', community_id=obj.id)}}">{{obj.title if obj.title else 'Untitled'}}</a>
+        <a href="{{url_for('.edit', community_name=obj.name)}}">{{obj.title if obj.title else 'Untitled'}}</a>
         <br />
         <small class="muted">{{ _('Identifier') }}: {{obj.id}}</small>
       </td>
@@ -45,9 +45,9 @@
             <span class="caret"></span>
           </a>
           <ul class="dropdown-menu">
-            <li><a href="{{url_for('.detail', community_id=obj.id)}}"><i class="icon-eye-open"></i> {{ _('View') }}</a></li>
-            <li><a href="{{url_for('.curate', community_id=obj.id)}}"><i class="icon-check"></i> {{ _('Curate') }}</a></li>
-            <li><a href="{{url_for('.edit', community_id=obj.id)}}"><i class="icon-pencil"></i> {{ _('Edit') }}</a></li>
+            <li><a href="{{url_for('.detail', community_name=obj.name)}}"><i class="icon-eye-open"></i> {{ _('View') }}</a></li>
+            <li><a href="{{url_for('.curate', community_name=obj.name)}}"><i class="icon-check"></i> {{ _('Curate') }}</a></li>
+            <li><a href="{{url_for('.edit', community_name=obj.name)}}"><i class="icon-pencil"></i> {{ _('Edit') }}</a></li>
           </ul>
         </div> <!-- /.btn-group -->
       </td>

--- a/invenio_communities/templates/invenio_communities/new.html
+++ b/invenio_communities/templates/invenio_communities/new.html
@@ -89,11 +89,11 @@
         </div>
       </div>
       <div class="modal-footer">
-        <form action="{{url_for('.delete', community_id=community.id)}}" method="POST">
+        <form action="{{url_for('.delete', community_name=community.name)}}" method="POST">
           {{form.csrf_token}}
           {%- for field in deleteform %}{{ field }}{% endfor %}
           <button class="btn btn-large" data-dismiss="modal" aria-hidden="true">No, thanks</button>
-          <button type="submit" href="{{ url_for('.delete', community_id=community.id) }}" class="btn btn-danger"><i class="icon-trash  icon-white"></i> Yes, delete</button>
+          <button type="submit" href="{{ url_for('.delete', community_name=community.name) }}" class="btn btn-danger"><i class="icon-trash  icon-white"></i> Yes, delete</button>
         </form>
       </div>
       </div>

--- a/invenio_communities/templates/invenio_communities/portalbox_main.html
+++ b/invenio_communities/templates/invenio_communities/portalbox_main.html
@@ -35,7 +35,7 @@
 {{ community.description|safe }}
 {%- endif %}
 {%- if community.page %}
-<a href="{{ url_for('invenio_communities.about', community_id=community.id) }}" class="pull-right">
+<a href="{{ url_for('invenio_communities.about', community_name=community.name) }}" class="pull-right">
   {{ _('Read more') }}
 </a>
 <br />

--- a/invenio_communities/views/ui.py
+++ b/invenio_communities/views/ui.py
@@ -56,8 +56,8 @@ blueprint = Blueprint(
 def pass_community(f):
     """Decorator to pass community."""
     @wraps(f)
-    def inner(community_id, *args, **kwargs):
-        c = Community.get(community_id)
+    def inner(community_name, *args, **kwargs):
+        c = Community.get(community_name=community_name)
         if c is None:
             abort(404)
         return f(c, *args, **kwargs)
@@ -128,14 +128,14 @@ def index():
     )
 
 
-@blueprint.route('/<string:community_id>/', methods=['GET'])
+@blueprint.route('/<string:community_name>/', methods=['GET'])
 @pass_community
 def detail(community):
     """Index page with uploader and list of existing depositions."""
     return generic_item(community, "invenio_communities/detail.html")
 
 
-@blueprint.route('/<string:community_id>/search', methods=['GET'])
+@blueprint.route('/<string:community_name>/search', methods=['GET'])
 @pass_community
 def search(community):
     """Index page with uploader and list of existing depositions."""
@@ -145,7 +145,7 @@ def search(community):
         detail=False)
 
 
-@blueprint.route('/<string:community_id>/about/', methods=['GET'])
+@blueprint.route('/<string:community_name>/about/', methods=['GET'])
 @pass_community
 def about(community):
     """Index page with uploader and list of existing depositions."""
@@ -182,11 +182,11 @@ def new():
     if form.validate_on_submit():
         data = copy.deepcopy(form.data)
 
-        community_id = data.pop('identifier')
+        community_name = data.pop('name')
         del data['logo']
 
         community = Community.create(
-            community_id, current_user.get_id(), **data)
+            community_name, current_user.get_id(), **data)
 
         file = request.files.get('logo', None)
         if file:
@@ -200,7 +200,7 @@ def new():
         if community:
             db.session.commit()
             flash("Community was successfully created.", category='success')
-            return redirect(url_for('.edit', community_id=community.id))
+            return redirect(url_for('.edit', community_name=community.name))
 
     return render_template(
         "/invenio_communities/new.html",
@@ -209,7 +209,7 @@ def new():
     )
 
 
-@blueprint.route('/<string:community_id>/edit/', methods=['GET', 'POST'])
+@blueprint.route('/<string:community_name>/edit/', methods=['GET', 'POST'])
 @login_required
 @pass_community
 @permission_required('community-edit')
@@ -239,7 +239,7 @@ def edit(community):
         if not form.logo.errors:
             db.session.commit()
             flash("Community successfully edited.", category='success')
-            return redirect(url_for('.edit', community_id=community.id))
+            return redirect(url_for('.edit', community_name=community.name))
 
     return render_template(
         "invenio_communities/new.html",
@@ -247,7 +247,7 @@ def edit(community):
     )
 
 
-@blueprint.route('/<string:community_id>/delete/', methods=['POST'])
+@blueprint.route('/<string:community_name>/delete/', methods=['POST'])
 @login_required
 @pass_community
 @permission_required('community-delete')
@@ -268,17 +268,17 @@ def delete(community):
         return redirect(url_for('.index'))
     else:
         flash("Community could not be deleted.", category='warning')
-        return redirect(url_for('.edit', community_id=community.id))
+        return redirect(url_for('.edit', community_name=community.name))
 
 
-@blueprint.route('/<string:community_id>/curate/', methods=['GET', 'POST'])
+@blueprint.route('/<string:community_name>/curate/', methods=['GET', 'POST'])
 @login_required
 @pass_community
 @permission_required('community-curate')
 def curate(community):
     """Index page with uploader and list of existing depositions.
 
-    :param community_id: ID of the community to curate.
+    :param community_name: name of the community to curate.
     """
     if request.method == 'POST':
         action = request.json.get('action')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -128,10 +128,11 @@ def communities(app, db, user):
     """Create some example communities."""
     user1 = db_.session.merge(user)
 
-    comm0 = Community.create(community_id='comm1', user_id=user1.id,
+    comm0 = Community.create(community_name='comm1', user_id=user1.id,
                              title='Title1', description='Description1')
-    comm1 = Community.create(community_id='comm2', user_id=user1.id, title='A')
-    comm2 = Community.create(community_id='oth3', user_id=user1.id)
+    comm1 = Community.create(community_name='comm2', user_id=user1.id,
+                             title='A')
+    comm2 = Community.create(community_name='oth3', user_id=user1.id)
     return comm0, comm1, comm2
 
 

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -41,7 +41,7 @@ def test_community_delete_task(app, db, communities):
     assert InclusionRequest.get(comm1.id, rec1.id)
 
     comm1.accept_record(rec1)
-    assert 'comm1' in rec1[communities_key]
+    assert str(comm1.id) in rec1[communities_key]
 
     comm1.delete()
     assert comm1.is_deleted


### PR DESCRIPTION
- NEW Renames previous community ID field as "name" and creates a new "id"
  field which is an UUID. UI endpoints still use the name, REST API
  endpoints use the new ID. (closes #84)

Signed-off-by: Nicolas Harraudeau nicolas.harraudeau@cern.ch
