### PR TITLE
email: template context variable fix

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2015, 2016 CERN.
+# Copyright (C) 2015, 2016, 2017 CERN.
 #
 # Invenio is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as

--- a/.editorconfig
+++ b/.editorconfig
@@ -40,6 +40,7 @@ known_first_party = invenio_communities
 known_third_party = alembic, invenio_accounts, invenio_db, invenio_records, invenio-files-rest, invenio_oaiserver
 multi_line_output = 2
 default_section = THIRDPARTY
+skip = .eggs
 
 # RST files (used by sphinx)
 [*.rst]

--- a/invenio_communities/alembic/2d9884d0e3fa_create_community_tables.py
+++ b/invenio_communities/alembic/2d9884d0e3fa_create_community_tables.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2016 CERN.
+# Copyright (C) 2016, 2017 CERN.
 #
 # Invenio is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as

--- a/invenio_communities/alembic/2d9884d0e3fa_create_community_tables.py
+++ b/invenio_communities/alembic/2d9884d0e3fa_create_community_tables.py
@@ -66,6 +66,7 @@ def upgrade():
         sa.Column('expires_at', sa.DateTime(), nullable=True),
         sa.ForeignKeyConstraint(
             ['id_community'], ['communities_community.id'],
+            name='fk_communities_community_record_id_community',
         ),
         sa.ForeignKeyConstraint(['id_record'], [u'records_metadata.id'], ),
         sa.ForeignKeyConstraint(['id_user'], [u'accounts_user.id'], ),
@@ -80,6 +81,7 @@ def upgrade():
         sa.Column('start_date', sa.DateTime(), nullable=False),
         sa.ForeignKeyConstraint(
             ['id_community'], [u'communities_community.id'],
+            name='fk_communities_featured_community_id_community',
         ),
         sa.PrimaryKeyConstraint('id')
     )

--- a/invenio_communities/models.py
+++ b/invenio_communities/models.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2013, 2014, 2015, 2016 CERN.
+# Copyright (C) 2013, 2014, 2015, 2016, 2017 CERN.
 #
 # Invenio is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as

--- a/invenio_communities/models.py
+++ b/invenio_communities/models.py
@@ -57,7 +57,10 @@ class InclusionRequest(db.Model, Timestamp):
 
     id_community = db.Column(
         db.String(100),
-        db.ForeignKey('communities_community.id'),
+        db.ForeignKey(
+            'communities_community.id',
+            # Explicitly naming the FK because of name length limit in MySQL
+            name='fk_communities_community_record_id_community'),
         primary_key=True
     )
     """Id of the community to which the record is applying."""
@@ -460,7 +463,12 @@ class FeaturedCommunity(db.Model, Timestamp):
     """Id of the featured entry."""
 
     id_community = db.Column(
-        db.String(100), db.ForeignKey(Community.id), nullable=False)
+        db.String(100),
+        db.ForeignKey(
+            Community.id,
+            # Explicitly naming the FK because of name length limit in MySQL
+            name='fk_communities_featured_community_id_community'),
+        nullable=False)
     """Id of the featured community."""
 
     start_date = db.Column(

--- a/invenio_communities/utils.py
+++ b/invenio_communities/utils.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2013, 2015, 2016 CERN.
+# Copyright (C) 2013, 2015, 2016, 2017 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as

--- a/invenio_communities/utils.py
+++ b/invenio_communities/utils.py
@@ -160,7 +160,7 @@ def format_request_email_templ(increq, template, **ctx):
     # Add minimal information to the contex (without overwriting).
     curate_link = '{site_url}/communities/{id}/curate/'.format(
         site_url=current_app.config['THEME_SITEURL'],
-        id=increq.community.id),
+        id=increq.community.id)
 
     min_ctx = dict(
         record=Record.get_record(increq.record.id),

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2016 CERN.
+# Copyright (C) 2016, 2017 CERN.
 #
 # Invenio is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -22,8 +22,9 @@
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
--e git+git://github.com/inveniosoftware/invenio-db#egg=invenio-db
+-e git+git://github.com/inveniosoftware/invenio-access#egg=invenio-access
 -e git+git://github.com/inveniosoftware/invenio-accounts#egg=invenio-accounts
--e git+git://github.com/inveniosoftware/invenio-records#egg=invenio-records
+-e git+git://github.com/inveniosoftware/invenio-db#egg=invenio-db
 -e git+git://github.com/inveniosoftware/invenio-files-rest#egg=invenio-files-rest
 -e git+git://github.com/inveniosoftware/invenio-oaiserver#egg=invenio-oaiserver
+-e git+git://github.com/inveniosoftware/invenio-records#egg=invenio-records


### PR DESCRIPTION
* Fixes an email rendering bug, caused by a context variable being
  a tuple because of a trailing comma. (closes #92)

Signed-off-by: Alexander Ioannidis <a.ioannidis@cern.ch>