### PR TITLE
Fix Internal Server Error if SECURITY_REGISTERABLE is False

### DIFF
--- a/invenio_communities/templates/invenio_communities/mycommunities.html
+++ b/invenio_communities/templates/invenio_communities/mycommunities.html
@@ -73,7 +73,11 @@
 {% else %}
   <h4>
     <div class="pull-right">
+      {%- if security.registerable %}
       &nbsp;<a href="{{url_for('security.register')}}" class="btn btn-warning btn-large signup">{{ _('Sign Up') }}</a>
+      {% else %}
+      &nbsp;<a href="{{url_for('security.login')}}" class="btn btn-warning btn-large">{{ _('Log in') }}</a>
+      {% endif %}
     </div>
     <strong>{{ _('Want your own community?') }}</strong>
   </h4>


### PR DESCRIPTION
Flask-Security allows to deactivate user registration, which is useful if only SSO should be allowed using the configuration variable (`SECURITY_REGISTERABLE`, https://pythonhosted.org/Flask-Security/configuration.html?highlight=security_registerable#feature-flags)

If the user is currently not authenticated and `SECURITY_REGISTERABLE = False` the invenio-communities frontpage shows an internal server error. (The endpoint cannot be built.)

Changed myccommunities template to show login button instead of Sign Up in case  `SECURITY_REGISTERABLE = False`.

If you prefer another solution, just tell me, but would be important for me to have a solution.

Fixes #105 