### PR TITLE
templates: description changed simple to advanced

### DIFF
--- a/invenio_communities/templates/invenio_communities/new.html
+++ b/invenio_communities/templates/invenio_communities/new.html
@@ -64,7 +64,7 @@
       }
   }
   init_ckeditor("page", 'advanced');
-  init_ckeditor("description", 'simple');
+  init_ckeditor("description", 'advanced');
   init_ckeditor("curation_policy", 'advanced');
   </script>
 {%- endblock javascript -%}


### PR DESCRIPTION
The field description in the new.html did not allow links, as the type was 'simple'. With type 'advanced' links are allowed.