### PR TITLE
config: set default records rest to avoid order errors

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,12 @@
 Changes
 =======
 
+Version 2.0.6 (released 2020-08-03)
+-----------------------------------
+
+- Uses ``react-invenio-forms``.
+- Adds config-based domains.
+
 Version 2.0.5 (released 2020-06-09)
 -----------------------------------
 

--- a/invenio_communities/ext.py
+++ b/invenio_communities/ext.py
@@ -71,12 +71,14 @@ class InvenioCommunities(object):
             if k.startswith('COMMUNITIES_'):
                 if k == 'COMMUNITIES_REST_ENDPOINTS':
                     # Make sure of registration process.
+                    app.config.setdefault('RECORDS_REST_ENDPOINTS', {})
                     app.config['RECORDS_REST_ENDPOINTS'].update(getattr(
                         config, k))
                 app.config.setdefault(k, getattr(config, k))
                 if k == 'COMMUNITIES_REST_FACETS':
                     # TODO Might be overriden depending on which package is
                     # initialised first
+                    app.config.setdefault('RECORDS_REST_FACETS', {})
                     app.config['RECORDS_REST_FACETS'].update(
                         getattr(config, k))
         app.config.setdefault(

--- a/invenio_communities/ext.py
+++ b/invenio_communities/ext.py
@@ -57,7 +57,8 @@ class InvenioCommunities(object):
         def record_context_processors():
             """Jinja context processors for communities record integration."""
             def record_communities(record):
-                from invenio_communities.records.api import RecordCommunitiesCollection, Record
+                from invenio_communities.records.api import Record, \
+                    RecordCommunitiesCollection
                 return RecordCommunitiesCollection(Record(record, model=record.model))
             return dict(record_communities=record_communities)
 

--- a/invenio_communities/marshmallow/json.py
+++ b/invenio_communities/marshmallow/json.py
@@ -12,6 +12,7 @@ from __future__ import absolute_import, print_function
 
 import uuid
 
+from flask import current_app
 from invenio_pidstore.models import PersistentIdentifier
 from invenio_records_rest.schemas import Nested, StrictKeysMixin
 from invenio_records_rest.schemas.fields import DateString, GenFunction, \
@@ -21,7 +22,6 @@ from werkzeug.local import LocalProxy
 
 from invenio_communities.api import Community
 from invenio_communities.proxies import current_communities
-from flask import current_app
 
 
 def pid_from_context_or_rec(data_value, context, **kwargs):

--- a/invenio_communities/version.py
+++ b/invenio_communities/version.py
@@ -14,4 +14,5 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = "2.0.5"
+__version__ = "2.0.6"
+

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -7,7 +7,7 @@
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
-isort -rc -c -df &&
+isort invenio_communities tests --check-only --diff &&
 check-manifest --ignore ".travis-*"
 
 # TODO: Enable when tests are in place


### PR DESCRIPTION
Loading errors do not occur anymore. However, I have not tested communities functionality after the changes.