### PR TITLE
communities-profile: fix validation message on rename

### DIFF
--- a/invenio_communities/assets/semantic-ui/js/invenio_communities/settings/profile/RenameCommunityButton.js
+++ b/invenio_communities/assets/semantic-ui/js/invenio_communities/settings/profile/RenameCommunityButton.js
@@ -34,7 +34,11 @@ export const RenameCommunityButton = (props) => {
       // TODO: replace it with proper link from the rename response
       window.location.href = `/communities/${newName}`;
     } catch (error) {
-      setError(error.response.data.message);
+      const responseErrors = error.response.data.errors;
+      const invalidIdError = responseErrors
+        .filter((error) => error.field == "id")
+        .map((error) => error.messages[0]);
+      setError(invalidIdError);
     }
   };
 


### PR DESCRIPTION
closes #301

# Screenshots
<img width="1099" alt="Screenshot 2021-04-28 at 17 43 54" src="https://user-images.githubusercontent.com/22594783/116433581-eef45100-a849-11eb-9385-a86c0b419a7c.png">
