### PR TITLE
ext: do not register routes and service if disabled

### DIFF
--- a/invenio_communities/ext.py
+++ b/invenio_communities/ext.py
@@ -30,8 +30,9 @@ class InvenioCommunities(object):
         self.init_config(app)
         app.extensions['invenio-communities'] = self
 
-        self.init_services(app)
-        self.init_resource(app)
+        if app.config["COMMUNITIES_ENABLED"]:
+            self.init_services(app)
+            self.init_resource(app)
 
     def init_config(self, app):
         """Initialize configuration.


### PR DESCRIPTION
- closes #349 

The first screenshot shows the API `url_map` with `COMMUNITIES_ENABLED=False`, the second with `COMMUNITIES_ENABLED=True`.

![Screenshot 2021-08-02 at 17 32 41](https://user-images.githubusercontent.com/6756943/127886954-cf4aecea-2f42-4f52-ad8a-3fe9dc352cac.png)

![Screenshot 2021-08-02 at 17 33 41](https://user-images.githubusercontent.com/6756943/127886950-1006d84a-807f-41e4-871a-5e971b68cce6.png)