### PR TITLE
global: remove invenio-rdm-records as dependency

### DIFF
--- a/invenio_communities/communities/records/jsonschemas/communities/communities-v1.0.0.json
+++ b/invenio_communities/communities/records/jsonschemas/communities/communities-v1.0.0.json
@@ -13,7 +13,7 @@
       "description": "Community identifier.",
       "type": "string"
     },
-    "pid": {"$ref": "local://records/definitions-v1.0.0.json#/internal-pid"},
+    "pid": {"$ref": "local://definitions-v1.0.0.json#/internal-pid"},
 
     "access": {
       "type": "object",
@@ -24,7 +24,7 @@
           "description": "List of owners of the child records.",
           "type": "array",
           "uniqueItems": true,
-          "items": {"$ref": "local://records/definitions-v1.0.0.json#/agent"}
+          "items": {"$ref": "local://communities/definitions-v2.0.0.json#/agent"}
         },
 
         "visibility": {
@@ -97,8 +97,8 @@
                 "additionalProperties": false,
                 "properties": {
                   "name": {"type": "string"},
-                  "identifier": {"$ref": "local://records/definitions-v1.0.0.json#/identifier"},
-                  "scheme": {"$ref": "local://records/definitions-v1.0.0.json#/scheme"}
+                  "identifier": {"$ref": "local://definitions-v1.0.0.json#/identifier"},
+                  "scheme": {"$ref": "local://definitions-v1.0.0.json#/scheme"}
                 }
               },
               "award": {
@@ -107,15 +107,15 @@
                 "properties": {
                   "title": {"type": "string"},
                   "number": {"type": "string"},
-                  "identifier": {"$ref": "local://records/definitions-v1.0.0.json#/identifier"},
-                  "scheme": {"$ref": "local://records/definitions-v1.0.0.json#/scheme"}
+                  "identifier": {"$ref": "local://definitions-v1.0.0.json#/identifier"},
+                  "scheme": {"$ref": "local://definitions-v1.0.0.json#/scheme"}
                 }
               }
             }
           }
         },
         "organizations": {
-          "$ref": "local://records/definitions-v1.0.0.json#/affiliations"
+          "$ref": "local://communities/definitions-v2.0.0.json#/affiliations"
         }
       }
     },

--- a/invenio_communities/communities/records/jsonschemas/communities/definitions-v2.0.0.json
+++ b/invenio_communities/communities/records/jsonschemas/communities/definitions-v2.0.0.json
@@ -1,0 +1,452 @@
+{
+  "affiliation": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "id": {
+        "$ref": "local://definitions-v1.0.0.json#/identifier"
+      },
+      "name": {
+        "type": "string"
+      }
+    }
+  },
+  "affiliations": {
+    "type": "array",
+    "items": {"$ref": "#/affiliation"},
+    "uniqueItems": true
+  },
+  "agent": {
+    "description": "An agent (user, software process, community, ...).",
+    "oneOf": [
+      {
+        "$ref": "#/user"
+      }
+    ]
+  },
+  "date_type": {
+    "type": "object",
+    "additionalProperties": false,
+    "description": "Type of the date.",
+    "properties": {
+      "id": {
+        "$ref": "local://definitions-v1.0.0.json#/identifier"
+      }
+    }
+  },
+  "description_type": {
+    "type": "object",
+    "additionalProperties": false,
+    "description": "A description type.",
+    "properties": {
+      "id": {
+        "type": "string"
+      }
+    }
+  },
+  "external-pid": {
+    "type": "object",
+    "description": "An external persistent identifier object.",
+    "additionalProperties": false,
+    "properties": {
+      "identifier": {
+        "$ref": "local://definitions-v1.0.0.json#/identifier"
+      },
+      "provider": {
+        "description": "The provider of the persistent identifier.",
+        "type": "string"
+      },
+      "client": {
+        "description": "Client identifier for the specific PID.",
+        "type": "string"
+      }
+    }
+  },
+  "file": {
+    "type": "object",
+    "additionalProperties": false,
+    "description": "A file object.",
+    "properties": {
+      "version_id": {
+        "description": "Object version ID.",
+        "type": "string"
+      },
+      "bucket_id": {
+        "description": "Object verison bucket ID.",
+        "type": "string"
+      },
+      "mimetype": {
+        "description": "File MIMEType.",
+        "type": "string"
+      },
+      "uri": {
+        "description": "File URI.",
+        "type": "string"
+      },
+      "storage_class": {
+        "description": "File storage class.",
+        "type": "string"
+      },
+      "checksum": {
+        "description": "Checksum of the file.",
+        "type": "string"
+      },
+      "size": {
+        "description": "Size of the file in bytes.",
+        "type": "number"
+      },
+      "key": {
+        "description": "Key (filename) of the file.",
+        "type": "string"
+      },
+      "file_id": {
+        "$ref": "local://definitions-v1.0.0.json#/identifier"
+      }
+    }
+  },
+  "GeoJSON-Geometry": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://geojson.org/schema/Geometry.json",
+    "title": "GeoJSON Geometry",
+    "oneOf": [
+      {
+        "title": "GeoJSON Point",
+        "type": "object",
+        "required": [
+          "type",
+          "coordinates"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "Point"
+            ]
+          },
+          "coordinates": {
+            "type": "array",
+            "minItems": 2,
+            "items": {
+              "type": "number"
+            }
+          },
+          "bbox": {
+            "type": "array",
+            "minItems": 4,
+            "items": {
+              "type": "number"
+            }
+          }
+        }
+      },
+      {
+        "title": "GeoJSON LineString",
+        "type": "object",
+        "required": [
+          "type",
+          "coordinates"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "LineString"
+            ]
+          },
+          "coordinates": {
+            "type": "array",
+            "minItems": 2,
+            "items": {
+              "type": "array",
+              "minItems": 2,
+              "items": {
+                "type": "number"
+              }
+            }
+          },
+          "bbox": {
+            "type": "array",
+            "minItems": 4,
+            "items": {
+              "type": "number"
+            }
+          }
+        }
+      },
+      {
+        "title": "GeoJSON Polygon",
+        "type": "object",
+        "required": [
+          "type",
+          "coordinates"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "Polygon"
+            ]
+          },
+          "coordinates": {
+            "type": "array",
+            "items": {
+              "type": "array",
+              "minItems": 4,
+              "items": {
+                "type": "array",
+                "minItems": 2,
+                "items": {
+                  "type": "number"
+                }
+              }
+            }
+          },
+          "bbox": {
+            "type": "array",
+            "minItems": 4,
+            "items": {
+              "type": "number"
+            }
+          }
+        }
+      },
+      {
+        "title": "GeoJSON MultiPoint",
+        "type": "object",
+        "required": [
+          "type",
+          "coordinates"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "MultiPoint"
+            ]
+          },
+          "coordinates": {
+            "type": "array",
+            "items": {
+              "type": "array",
+              "minItems": 2,
+              "items": {
+                "type": "number"
+              }
+            }
+          },
+          "bbox": {
+            "type": "array",
+            "minItems": 4,
+            "items": {
+              "type": "number"
+            }
+          }
+        }
+      },
+      {
+        "title": "GeoJSON MultiLineString",
+        "type": "object",
+        "required": [
+          "type",
+          "coordinates"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "MultiLineString"
+            ]
+          },
+          "coordinates": {
+            "type": "array",
+            "items": {
+              "type": "array",
+              "minItems": 2,
+              "items": {
+                "type": "array",
+                "minItems": 2,
+                "items": {
+                  "type": "number"
+                }
+              }
+            }
+          },
+          "bbox": {
+            "type": "array",
+            "minItems": 4,
+            "items": {
+              "type": "number"
+            }
+          }
+        }
+      },
+      {
+        "title": "GeoJSON MultiPolygon",
+        "type": "object",
+        "required": [
+          "type",
+          "coordinates"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "MultiPolygon"
+            ]
+          },
+          "coordinates": {
+            "type": "array",
+            "items": {
+              "type": "array",
+              "items": {
+                "type": "array",
+                "minItems": 4,
+                "items": {
+                  "type": "array",
+                  "minItems": 2,
+                  "items": {
+                    "type": "number"
+                  }
+                }
+              }
+            }
+          },
+          "bbox": {
+            "type": "array",
+            "minItems": 4,
+            "items": {
+              "type": "number"
+            }
+          }
+        }
+      }
+    ]
+  },
+  "identifiers": {
+    "description": "Identifiers object (keys being scheme, value being the identifier).",
+    "type": "object",
+    "additionalProperties": {
+      "$ref": "local://definitions-v1.0.0.json#/identifier"
+    }
+  },
+  "language": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "id": {
+        "$ref": "local://definitions-v1.0.0.json#/identifier"
+      }
+    }
+  },
+  "latitude": {
+    "type": "number",
+    "minimum": -90,
+    "maximum": 90
+  },
+  "longitude": {
+    "type": "number",
+    "minimum": -180,
+    "maximum": 180
+  },
+  "nameType": {
+    "description": "Type of name.",
+    "type": "string",
+    "enum": [
+      "personal",
+      "organizational"
+    ]
+  },
+  "person_or_org": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "name": {
+        "type": "string"
+      },
+      "type": {
+        "$ref": "#/nameType"
+      },
+      "given_name": {
+        "type": "string"
+      },
+      "family_name": {
+        "type": "string"
+      },
+      "identifiers": {
+        "type": "array",
+        "items": {
+          "$ref": "local://definitions-v1.0.0.json#/identifiers_with_scheme"
+        },
+        "uniqueItems": true
+      }
+    }
+  },
+  "relation_type": {
+    "type": "object",
+    "additionalProperties": false,
+    "description": "A relation type.",
+    "properties": {
+      "id": {
+        "$ref": "local://definitions-v1.0.0.json#/identifier"
+      }
+    }
+  },
+  "resource_type": {
+    "type": "object",
+    "additionalProperties": false,
+    "description": "A resource type.",
+    "properties": {
+      "id": {
+        "$ref": "local://definitions-v1.0.0.json#/identifier"
+      }
+    }
+  },
+  "role": {
+    "description": "Role of creator/contributor.",
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "id": {
+        "$ref": "local://definitions-v1.0.0.json#/identifier"
+      }
+    }
+  },
+  "subject": {
+    "description": "Term related to entry.",
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "id": {
+        "$ref": "local://definitions-v1.0.0.json#/identifier"
+      },
+      "subject": {
+        "type": "string"
+      }
+    }
+  },
+  "subjects": {
+    "type": "array",
+    "items": {"$ref": "#/subject"},
+    "uniqueItems": true
+  },
+  "title_type": {
+    "description": "Type of title.",
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "id": {
+        "$ref": "local://definitions-v1.0.0.json#/identifier"
+      }
+    }
+  },
+  "user": {
+    "type": "object",
+    "description": "User object.",
+    "additionalProperties": false,
+    "properties": {
+      "user": {
+        "type": "integer"
+      }
+    }
+  }
+}

--- a/invenio_communities/communities/records/systemfields/owners.py
+++ b/invenio_communities/communities/records/systemfields/owners.py
@@ -1,0 +1,137 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 TU Wien.
+# Copyright (C) 2021 CERN.
+#
+# Invenio-Communities is free software; you can redistribute it and/or modify
+# it under the terms of the MIT License; see LICENSE file for more details.
+
+"""Owners classes for the access system field."""
+
+from invenio_accounts.models import User
+
+# TODO: Move to Invenio-Records-Resources and make reusable. Duplicated from
+# Invenio-RDM-Records.
+class Owner:
+    """An abstraction between owner entities and specifications as dicts."""
+
+    def __init__(self, owner):
+        """Create an owner from either a dictionary or a User."""
+        self._entity = None
+        self.owner_type = None
+        self.owner_id = None
+
+        if isinstance(owner, dict):
+            if "user" in owner:
+                self.owner_type = "user"
+                self.owner_id = owner["user"]
+
+            else:
+                raise ValueError("unknown owner type: {}".format(owner))
+
+        elif isinstance(owner, User):
+            self._entity = owner
+            self.owner_id = owner.id
+            self.owner_type = "user"
+
+        else:
+            raise TypeError("invalid owner type: {}".format(type(owner)))
+
+    def dump(self):
+        """Dump the owner to a dictionary."""
+        return {self.owner_type: self.owner_id}
+
+    def resolve(self, raise_exc=False):
+        """Resolve the owner entity (e.g. User) via a database query."""
+        if self._entity is None:
+            if self.owner_type == "user":
+                self._entity = User.query.get(self.owner_id)
+
+            else:
+                raise ValueError(
+                    "unknown owner type: {}".format(self.owner_type)
+                )
+
+            if self._entity is None and raise_exc:
+                raise LookupError(
+                    "could not find owner: {}".format(self.dump())
+                )
+
+        return self._entity
+
+    @property
+    def user(self):
+        if self.owner_type == 'user':
+            return self.owner_id
+
+    def __hash__(self):
+        """Return hash(self)."""
+        return hash(self.owner_type) + hash(self.owner_id)
+
+    def __eq__(self, other):
+        """Return self == other."""
+        if type(self) != type(other):
+            return False
+
+        return (
+            self.owner_type == other.owner_type
+            and self.owner_id == other.owner_id
+        )
+
+    def __ne__(self, other):
+        """Return self != other."""
+        return not self == other
+
+    def __str__(self):
+        """Return str(self)."""
+        return str(self.resolve())
+
+    def __repr__(self):
+        """Return repr(self)."""
+        return repr(self.resolve())
+
+
+class Owners(list):
+    """A list of owners for a record."""
+
+    owner_cls = Owner
+
+    def __init__(self, owners=None, owner_cls=None):
+        """Create a new list of owners."""
+        self.owner_cls = owner_cls or self.owner_cls
+        for owner in owners or []:
+            self.add(owner)
+
+    def add(self, owner):
+        """Alias for self.append(owner)."""
+        self.append(owner)
+
+    def append(self, owner):
+        """Add the specified owner to the list of owners.
+
+        :param owner: The record's owner (either a dict, User or Owner).
+        """
+        if not isinstance(owner, self.owner_cls):
+            owner = self.owner_cls(owner)
+
+        if owner not in self:
+            super().append(owner)
+
+    def extend(self, owners):
+        """Add all new items from the specified owners to this list."""
+        for owner in owners:
+            self.add(owner)
+
+    def remove(self, owner):
+        """Remove the specified owner from the list of owners.
+
+        :param owner: The record's owner (either a dict, User or Owner).
+        """
+        if not isinstance(owner, self.owner_cls):
+            owner = self.owner_cls(owner)
+
+        super().remove(owner)
+
+    def dump(self):
+        """Dump the owners as a list of owner dictionaries."""
+        return [owner.dump() for owner in self]

--- a/invenio_communities/communities/schema.py
+++ b/invenio_communities/communities/schema.py
@@ -8,13 +8,12 @@
 
 """Community schema."""
 
-from flask import current_app
 from flask_babelex import lazy_gettext as _
-from invenio_rdm_records.services.schemas.metadata import AffiliationSchema, \
-    FundingSchema
-from invenio_rdm_records.services.schemas.parent.access import Agent
 from invenio_records_resources.services.records.schema import BaseRecordSchema
-from marshmallow import Schema, fields, missing, validate
+from invenio_vocabularies.contrib.affiliations.schema import \
+    AffiliationRelationSchema
+from invenio_vocabularies.contrib.awards.schema import FundingRelationSchema
+from marshmallow import Schema, fields, validate
 from marshmallow_utils.fields import NestedAttribute, SanitizedHTML, \
     SanitizedUnicode
 
@@ -22,7 +21,19 @@ from marshmallow_utils.fields import NestedAttribute, SanitizedHTML, \
 def _not_blank(**kwargs):
     """Returns a non-blank validation rule."""
     max_ = kwargs.get('max','')
-    return validate.Length(error=_(f'Not empty string and less than {max_} characters allowed.'), min=1, **kwargs)
+    return validate.Length(
+        error=_(f'Not empty string and less than {max_} characters allowed.'),
+        min=1,
+        **kwargs
+    )
+
+
+# TODO: Move to Invenio-Records-Resources and make reusable (duplicated from
+# Invenio-RDM-Records).
+class Agent(Schema):
+    """An agent schema."""
+
+    user = fields.Integer(required=True)
 
 
 class CommunityAccessSchema(Schema):
@@ -65,8 +76,8 @@ class CommunityMetadataSchema(Schema):
         validate=validate.OneOf(COMMUNITY_TYPES)
     )
     website = fields.Url(validate=_not_blank())
-    funding = fields.List(fields.Nested(FundingSchema))
-    organizations = fields.List(fields.Nested(AffiliationSchema))
+    funding = fields.List(fields.Nested(FundingRelationSchema))
+    organizations = fields.List(fields.Nested(AffiliationRelationSchema))
 
     # TODO: Add when general vocabularies are ready
     # domains = fields.List(fields.Str())

--- a/invenio_communities/communities/services/components.py
+++ b/invenio_communities/communities/services/components.py
@@ -10,7 +10,6 @@ import re
 
 from invenio_access.permissions import system_process
 from invenio_pidstore.errors import PIDAlreadyExists
-from invenio_rdm_records.services.components import AccessComponent
 from invenio_records_resources.services.records.components import \
     ServiceComponent
 from marshmallow.exceptions import ValidationError
@@ -69,7 +68,61 @@ class PIDComponent(ServiceComponent):
                 field_name='id',
             )
 
+# TODO: Move to Invenio-Records-Resources (and make reusable). Duplicated from
+# Invenio-RDM-Records.
+class AccessComponent(ServiceComponent):
+    """Service component for access integration."""
 
+    def _populate_access_and_validate(self, identity, data, record, **kwargs):
+        """Populate and validate the record's access field."""
+        if record is not None and "access" in data:
+            # populate the record's access field with the data already
+            # validated by marshmallow
+            record.update({"access": data.get("access")})
+            record.access.refresh_from_dict(record.get("access"))
+
+        errors = record.access.errors
+        if errors:
+            # filter out duplicate error messages
+            messages = list({str(e) for e in errors})
+            raise ValidationError(messages, field_name="access")
+
+    def _init_owners(self, identity, record, **kwargs):
+        """If the record has no owners yet, add the current user."""
+        # if the given identity is that of a user, we add the
+        # corresponding user to the owners
+        # (record.parent.access.owners) and commit the parent
+        # otherwise, the parent's owners stays empty
+        is_sys_id = system_process in identity.provides
+        if not record.parent.access.owners and not is_sys_id:
+            owner_dict = {"user": identity.id}
+            record.parent.access.owners.add(owner_dict)
+            record.parent.commit()
+
+    def create(self, identity, data=None, record=None, **kwargs):
+        """Add basic ownership fields to the record."""
+        self._populate_access_and_validate(identity, data, record, **kwargs)
+        self._init_owners(identity, record, **kwargs)
+
+    def update_draft(self, identity, data=None, record=None, **kwargs):
+        """Update handler."""
+        self._populate_access_and_validate(identity, data, record, **kwargs)
+
+    def publish(self, identity, draft=None, record=None, **kwargs):
+        """Update draft metadata."""
+        record.access = draft.access
+
+    def edit(self, identity, draft=None, record=None, **kwargs):
+        """Update draft metadata."""
+        draft.access = record.access
+
+    def new_version(self, identity, draft=None, record=None, **kwargs):
+        """Update draft metadata."""
+        draft.access = record.access
+
+
+# TODO: Move to Invenio-Records-Resources (and make reusable). Duplicated from
+# Invenio-RDM-Records.
 class CommunityAccessComponent(AccessComponent):
     """Service component for access integration."""
 

--- a/invenio_communities/communities/services/permissions.py
+++ b/invenio_communities/communities/services/permissions.py
@@ -2,36 +2,95 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2016-2021 CERN.
+# Copyright (C) 2021 Graz University of Technology.
+# Copyright (C) 2021 TU Wien.
+
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
 """Community permissions."""
 
+import operator
+from functools import reduce
+from itertools import chain
+
 from elasticsearch_dsl.query import Q
 from flask_principal import UserNeed
 from invenio_access.permissions import any_user
-from invenio_rdm_records.services.generators import \
-    IfRestricted as IfRestrictedBase
 from invenio_records_permissions.generators import AnyUser, \
     AuthenticatedUser, Generator, SystemProcess
 from invenio_records_permissions.policies import BasePermissionPolicy
 
 
-class IfRestricted(IfRestrictedBase):
-    """IfRestricted.
+# TODO: Move class to Invenio-Records-Permissions and make more reusable ()
+class IfRestrictedBase(Generator):
+    """IfRestricted generator.
 
     IfRestricted(
         'record',
         then_=[RecordPermissionLevel('view')],
         else_=[ActionNeed(superuser-access)],
     )
-
-    A record permission level defines an aggregated set of
-    low-level permissions,
-    that grants increasing level of permissions to a record.
-
     """
+
+    def __init__(self, field, then_, else_):
+        """Constructor."""
+        self.field = field
+        self.then_ = then_
+        self.else_ = else_
+
+    def generators(self, record):
+        """Get the "then" or "else" generators."""
+        if record is None:
+            # TODO - when permissions on links are checked, the record is not
+            # passes properly, causing below ``record.access`` to fail.
+            return self.else_
+        # TODO: Next statement should be made more reusable
+        is_restricted = getattr(
+            record.access.protection, self.field, "restricted")
+        return self.then_ if is_restricted == "restricted" else self.else_
+
+    def needs(self, record=None, **kwargs):
+        """Set of Needs granting permission."""
+        needs = [
+            g.needs(record=record, **kwargs) for g in self.generators(record)]
+        return set(chain.from_iterable(needs))
+
+    def excludes(self, record=None, **kwargs):
+        """Set of Needs denying permission."""
+        needs = [
+            g.excludes(record=record, **kwargs) for g in self.generators(
+                record)]
+        return set(chain.from_iterable(needs))
+
+    def make_query(self, generators, **kwargs):
+        """Make a query for one set of generators."""
+        queries = [g.query_filter(**kwargs) for g in generators]
+        queries = [q for q in queries if q]
+        return reduce(operator.or_, queries) if queries else None
+
+    def query_filter(self, **kwargs):
+        """Filters for current identity as super user."""
+        # TODO: Next two statement should be made more reusable
+        q_restricted = Q("match", **{f"access.{self.field}": "restricted"})
+        q_public = Q("match", **{f"access.{self.field}": "public"})
+        then_query = self.make_query(self.then_, **kwargs)
+        else_query = self.make_query(self.else_, **kwargs)
+
+        if then_query and else_query:
+            return (q_restricted & then_query) | (q_public & else_query)
+        elif then_query:
+            return (q_restricted & then_query) | q_public
+        elif else_query:
+            return q_public & else_query
+        else:
+            return q_public
+
+
+# TODO: Remove class once IfRestrictedBase has been moved.
+class IfRestricted(IfRestrictedBase):
+    """IfRestricted."""
 
     def generators(self, record):
         """Get the "then" or "else" generators."""

--- a/setup.py
+++ b/setup.py
@@ -18,8 +18,9 @@ readme = open('README.rst').read()
 history = open('CHANGES.rst').read()
 
 tests_require = [
+    'Faker>=2.0.3',
     'invenio-app>=1.3.2,<2.0.0',
-    'pytest-invenio>=1.4.2,<2.0.0'
+    'pytest-invenio>=1.4.2,<2.0.0',
 ]
 
 invenio_db_version = '>=1.0.9,<2.0.0'
@@ -63,7 +64,7 @@ setup_requires = [
 install_requires = [
     'invenio-files-rest>=1.3.0',
     'invenio-mail>=1.0.2',
-    'invenio-rdm-records>=0.33.1,<0.34.0',
+    'invenio-vocabularies>=0.9.2,<0.10.0'
 ]
 
 packages = find_packages()

--- a/tests/communities/alembic/test_alembic.py
+++ b/tests/communities/alembic/test_alembic.py
@@ -10,6 +10,12 @@
 
 import pytest
 from invenio_db.utils import drop_alembic_version_table
+# Invenio-Vocabularies define an Alembic migration that include subjects and
+# affiliations tables. The SQLAlchemy models are however not registered by
+# default. This means that when alembic creates the database vs when SQLAlchemy
+# creates the database there's a discrepancy. Importing the subjects model
+# here, ensures the model get's registered, and we avoid the discrepancy.
+from invenio_vocabularies.contrib.subjects import models
 
 
 def test_alembic(base_app, database):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,5 +23,7 @@ def app_config(app_config):
         "invenio_records.resolver.InvenioRefResolver"
     app_config['RECORDS_REFRESOLVER_STORE'] = \
         "invenio_jsonschemas.proxies.current_refresolver_store"
+    # Variable not used. We set it to silent warnings
+    app_config['JSONSCHEMAS_HOST'] = 'not-used'
 
     return app_config


### PR DESCRIPTION
Depends on PR in Invenio-Vocabularies yet to be opened.

This PR removes the dependency on Invenio-RDM-Records. This is a first step which duplicates part of the code. A further step is needed later to move the duplicated code to Invenio-Records-Resources/Permissions and make both RDM-Records and Communities use this. Some design changes are however needed, to make it more reusable, and thus this is only a first step to untangle deps.