### PR TITLE
Community Needs

### DIFF
--- a/invenio_communities/communities/__init__.py
+++ b/invenio_communities/communities/__init__.py
@@ -9,10 +9,11 @@
 """Community Service API."""
 
 from .resources import CommunityResource, CommunityResourceConfig
-from .services import CommunityFileServiceConfig, CommunityService, \
-    CommunityServiceConfig, SearchOptions
+from .services import CommunityFileServiceConfig, CommunityNeed, \
+    CommunityService, CommunityServiceConfig, SearchOptions
 
 __all__ = (
+    'CommunityNeed',
     'CommunityService',
     'CommunityServiceConfig',
     'CommunityFileServiceConfig',

--- a/invenio_communities/communities/services/__init__.py
+++ b/invenio_communities/communities/services/__init__.py
@@ -10,9 +10,11 @@
 
 from .config import CommunityFileServiceConfig, CommunityServiceConfig, \
     SearchOptions
+from .permissions import CommunityNeed
 from .service import CommunityService
 
 __all__ = (
+    'CommunityNeed',
     'CommunityService',
     'CommunityServiceConfig',
     'CommunityFileServiceConfig',

--- a/invenio_communities/communities/services/permissions.py
+++ b/invenio_communities/communities/services/permissions.py
@@ -12,15 +12,18 @@
 """Community permissions."""
 
 import operator
-from functools import reduce
+from functools import partial, reduce
 from itertools import chain
 
 from elasticsearch_dsl.query import Q
-from flask_principal import UserNeed
+from flask_principal import Need, UserNeed
 from invenio_access.permissions import any_user
 from invenio_records_permissions.generators import AnyUser, \
     AuthenticatedUser, Generator, SystemProcess
 from invenio_records_permissions.policies import BasePermissionPolicy
+
+# TODO this is temporary and should be revisited when membership is a thing
+CommunityNeed = partial(Need, "community")
 
 
 # TODO: Move class to Invenio-Records-Permissions and make more reusable ()

--- a/invenio_communities/ext.py
+++ b/invenio_communities/ext.py
@@ -8,6 +8,7 @@
 
 """Invenio communities extension."""
 
+from flask_principal import identity_loaded
 from invenio_records_resources.services import FileService
 
 from invenio_communities.communities import CommunityFileServiceConfig, \
@@ -15,6 +16,7 @@ from invenio_communities.communities import CommunityFileServiceConfig, \
     CommunityServiceConfig
 
 from . import config
+from .utils import load_community_needs
 
 
 class InvenioCommunities(object):
@@ -33,6 +35,7 @@ class InvenioCommunities(object):
         if app.config["COMMUNITIES_ENABLED"]:
             self.init_services(app)
             self.init_resource(app)
+            self.init_hooks(app)
 
     def init_config(self, app):
         """Initialize configuration.
@@ -58,3 +61,9 @@ class InvenioCommunities(object):
             CommunityResourceConfig,
             self.service,
         )
+
+    def init_hooks(self, app):
+        """Initialize hooks."""
+        @identity_loaded.connect_via(app)
+        def on_identity_loaded(_, identity):
+            load_community_needs(identity, self.service)

--- a/invenio_communities/requests/resolver.py
+++ b/invenio_communities/requests/resolver.py
@@ -17,6 +17,21 @@ from invenio_requests.resolvers.default import RecordResolver
 from invenio_requests.resolvers.default.records import RecordPKProxy
 
 from ..communities.records.api import Community
+from ..communities.services.permissions import CommunityNeed
+
+
+class CommunityPKProxy(RecordPKProxy):
+    """Resolver proxy for a Record entity using the UUID."""
+
+    def get_need(self):
+        """Return the user need of the community's owner."""
+        # TODO this may become difficult once there's multiple levels
+        #      of membership (owner, manager, curator, ...)
+        #      -> which needs should be generated? None, and let the
+        #         user create the set of required needs from the
+        #         resolved entity? or keep the 'owner' need?
+        comid = str(self._parse_ref_dict_id(self._ref_dict))
+        return CommunityNeed(comid)
 
 
 class CommunityResolver(RecordResolver):
@@ -32,7 +47,7 @@ class CommunityResolver(RecordResolver):
     def __init__(self):
         """Initialize the default record resolver."""
         super().__init__(
-            Community, type_key=self.type_id, proxy_cls=RecordPKProxy)
+            Community, type_key=self.type_id, proxy_cls=CommunityPKProxy)
 
     def _reference_entity(self, entity):
         """Create a reference dict for the given record."""


### PR DESCRIPTION
Add Community Needs (currently only hinting at ownership of a community, because we don't have any other memberships yet), and add a function which automatically adds the Community Needs to a user's identity for all communities owned by said user.
Because this function is called very often (every request), we cache the results in the session and use a timeout-based mechanism for invalidating the cache.

This will have to be revisited when we have community memberships.