### PR TITLE
config: make service configs configurable

### DIFF
--- a/invenio_communities/config.py
+++ b/invenio_communities/config.py
@@ -9,6 +9,9 @@
 """Default configuration."""
 
 from invenio_communities.communities.services import facets
+from invenio_communities.communities import CommunityServiceConfig, CommunityFileServiceConfig
+from invenio_communities.invitations import InvitationServiceConfig
+from invenio_communities.members import MemberServiceConfig
 
 COMMUNITIES_MEMBERSHIP_REQUESTS_CONFIRMLINK_EXPIRES_IN = 1000000
 
@@ -41,6 +44,18 @@ COMMUNITIES_DOMAINS = [
     {'text': 'Studies in Creative Arts and Writing', 'value': 'studies_in_creative_arts_and_writing'},
     {'text': 'Studies in Human Society', 'value': 'studies_in_human_society'},
 ]
+
+COMMUNITIES_COMMUNITY_SERVICE_CONFIG = CommunityServiceConfig
+"""Configuration of Community service."""
+
+COMMUNITIES_FILE_SERVICE_CONFIG = CommunityFileServiceConfig
+"""Configuration of Communities file service."""
+
+COMMUNITIES_INVITATION_SERVICE_CONFIG = InvitationServiceConfig
+"""Configuration of Communities invitation service."""
+
+COMMUNITIES_MEMBER_SERVICE_CONFIG = MemberServiceConfig
+"""Configuration of Communities member service."""
 
 COMMUNITIES_ROUTES = {
     'frontpage': '/communities',

--- a/invenio_communities/ext.py
+++ b/invenio_communities/ext.py
@@ -54,11 +54,12 @@ class InvenioCommunities(object):
     def init_services(self, app):
         """Initialize communities service."""
         # Services
+
         self.service = CommunityService(
-            CommunityServiceConfig,
-            files_service=FileService(CommunityFileServiceConfig),
-            invitations_service=InvitationService(InvitationServiceConfig()),
-            members_service=MemberService(MemberServiceConfig())
+            config=app.config["COMMUNITIES_COMMUNITY_SERVICE_CONFIG"],
+            files_service=FileService(app.config["COMMUNITIES_FILE_SERVICE_CONFIG"]),
+            invitations_service=InvitationService(app.config["COMMUNITIES_INVITATION_SERVICE_CONFIG"]),
+            members_service=MemberService(app.config["COMMUNITIES_MEMBER_SERVICE_CONFIG"])
         )
 
     def init_resource(self, app):


### PR DESCRIPTION
This enables users of the module to override default configs of the provided services.

One could implement & provide their own `ServiceConfig` class inheriting from `CommunityServiceConfig`,
and e.g. customize PermissionPolicies, record links, add fields to Community records through
extending record schema, etc.
