### PR TITLE
allow system process to read communities

### DIFF
--- a/invenio_communities/permissions.py
+++ b/invenio_communities/permissions.py
@@ -31,8 +31,10 @@ class CommunityPermissionPolicy(BasePermissionPolicy):
         IfRestricted(
             'visibility',
             then_=[CommunityMembers()],
-            else_=[AnyUser()]),
-        ]
+            else_=[AnyUser()]
+        ),
+        SystemProcess(),
+    ]
 
     can_update = [CommunityOwners(), SystemProcess()]
 


### PR DESCRIPTION
To be honest, the system process can probably just do everything.
In which case, it might be best to add it to invenio-rdm-permissions
like we did for the admin user, so that we don't have to add it
everywhere in the future.

This came about while working on our importer.