### PR TITLE
members: list also accepted invitations

### DIFF
--- a/invenio_communities/members/services/service.py
+++ b/invenio_communities/members/services/service.py
@@ -500,9 +500,13 @@ class MemberService(RecordService):
         assert identity == system_identity
         member = self.record_cls.get_member_by_request(request_id)
         assert member.active is False
+        archived_invitation = ArchivedInvitation.create_from_member(member)
         member.active = True
         # TODO: recompute permissions for member.
         uow.register(RecordCommitOp(member, indexer=self.indexer))
+        uow.register(
+            RecordCommitOp(archived_invitation, indexer=self.archive_indexer))
+        uow.register(IndexRefreshOp(index=self.record_cls.index))
 
     @unit_of_work()
     def decline_invite(self, identity, request_id, uow=None):

--- a/tests/members/test_members_services.py
+++ b/tests/members/test_members_services.py
@@ -332,9 +332,14 @@ def test_invite_accept_flow(
         invite_user.identity, invite_request_id, 'accept').to_dict()
 
     # See new member in list
-    Member.index.refresh()
     res = member_service.search(owner.identity, community._record.id)
     assert res.to_dict()['hits']['total'] == 2
+
+    # See invitation in archived list
+    ArchivedInvitation.index.refresh()
+    res = member_service.search_invitations(
+        owner.identity, community._record.id)
+    assert res.to_dict()['hits']['total'] == 1
 
 
 def test_invite_decline_flow(


### PR DESCRIPTION
* The list of invitations should also display accepted invitations.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/best-practices/i18n/) (for relevant code).
- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines (for relevant code).
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines (for relevant code).
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines (for relevant code).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).

**Third-party code**

If you've added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
