### PR TITLE
frontpage: align community header content

### DIFF
--- a/invenio_communities/templates/semantic-ui/invenio_communities/frontpage.html
+++ b/invenio_communities/templates/semantic-ui/invenio_communities/frontpage.html
@@ -24,28 +24,27 @@
         {{_('Communities')}}
       </h1>
     </div>
-    <div class="centered two column row">
-      <div class="one wide column"></div>
-      <div class="six wide column">
+    <div class="one column row">
+      <div class="thirteen wide mobile ten wide tablet eight wide computer center aligned column">
         <p>
           {{_('Organize, curate and collaborate on records for your institution, project, topic or event.')}}
         </p>
       </div>
-      <div class="three wide column center">
+    </div>
+    <div class="two column stackable row">
+      <div class="eight wide tablet five wide computer column">
+        <form action="{{ url_for('invenio_communities.communities_search') }}" class="ui form">
+          <div class="ui fluid action input">
+            <input type="text" name="q" class="form-control" placeholder="{{ _('Search communities') }}">
+            <button type="submit" class="ui icon search button"><i class="search icon"></i></button>
+          </div>
+        </form>
+      </div>
+      <div class="three wide mobile five wide tablet three wide computer stretched column">
         <a href="{{ config.COMMUNITIES_ROUTES['new'] }}" class="ui icon left labeled positive button" role="button">
           <i class="icon plus"></i>
           {{_('New community')}}
         </a>
-      </div>
-    </div>
-    <div class="row">
-      <div class="eight wide column p-0">
-        <form action="{{ url_for('invenio_communities.communities_search') }}" class="ui form">
-          <div class="ui fluid action input">
-            <input type="text" name="q" class="form-control" placeholder="{{ _("Search communities") }}">
-            <button type="submit" class="ui icon search button"><i class="search icon"></i></button>
-          </div>
-        </form>
       </div>
     </div>
     <div class="ui divider hidden"></div>


### PR DESCRIPTION
Closes [#1431](https://github.com/inveniosoftware/invenio-app-rdm/issues/1431)

## Screenshots
Need https://github.com/inveniosoftware/invenio-app-rdm/pull/1445 to make the container (w/background color) span the full width of the page. 

*Note:* Please ignore the global header menu which is overlapping on mobile&tablet (solved in a different PR).
<img width="1543" alt="Screenshot 2022-04-14 at 08 49 34" src="https://user-images.githubusercontent.com/21052053/163331911-67785aa4-b22d-41db-af87-22c21a347820.png">
<img width="882" alt="Screenshot 2022-04-14 at 08 49 42" src="https://user-images.githubusercontent.com/21052053/163331921-c63fd538-7f9d-4a03-b1ef-84c2353c66ca.png">
<img width="355" alt="Screenshot 2022-04-14 at 08 49 56" src="https://user-images.githubusercontent.com/21052053/163331962-b658d026-81a4-4e12-b058-9a6562b93863.png">

