### PR TITLE
fix: pass along params and es_preferences

### DIFF
--- a/invenio_communities/members/services/service.py
+++ b/invenio_communities/members/services/service.py
@@ -281,8 +281,8 @@ class MemberService(RecordService):
             'members_search',
             self.member_dump_schema,
             self.config.search,
-            params=None,
-            es_preference=None,
+            params=params,
+            es_preference=es_preference,
             **kwargs
         )
 
@@ -303,8 +303,8 @@ class MemberService(RecordService):
             self.public_dump_schema,
             self.config.search_public,
             extra_filter=Q('term', **{'visible': True}),
-            params=None,
-            es_preference=None,
+            params=params,
+            es_preference=es_preference,
             **kwargs
         )
 
@@ -324,8 +324,8 @@ class MemberService(RecordService):
             self.config.search_invitations,
             record_cls=ArchivedInvitation,
             extra_filter=Q('term', **{'active': False}),
-            params=None,
-            es_preference=None,
+            params=params,
+            es_preference=es_preference,
             **kwargs
         )
 

--- a/tests/members/test_members_resource.py
+++ b/tests/members/test_members_resource.py
@@ -224,6 +224,25 @@ def test_search(
     assert hit['permissions']['can_update_visible'] is True
     assert hit['visible'] is False
 
+    # Pagination params should be passed correctly as well.
+    # see https://github.com/inveniosoftware/invenio-communities/issues/495
+    r1 = client.get(
+        f'/communities/{community_id}/members',
+        headers=headers,
+        query_string={"page": 1, "size": 1},
+    ).json
+    assert r1['hits']['total'] == 2
+    assert len(r1['hits']['hits']) == 1
+
+    r2 = client.get(
+        f'/communities/{community_id}/members',
+        headers=headers,
+        query_string={"page": 2, "size": 1},
+    ).json
+    assert r2['hits']['total'] == 2
+    assert len(r2['hits']['hits']) == 1
+    assert r1['hits']['hits'][0]["id"] != r2['hits']['hits'][0]
+
 
 def test_search_public(
     client, headers, community_id, new_user, public_reader, clean_index):


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

closes #495 
Pass along `params` and `es_preferences` to other functions in the search methods for members and invitations. 

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/best-practices/i18n/) (for relevant code).
- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines (for relevant code).
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines (for relevant code).
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines (for relevant code).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).

**Third-party code**

If you've added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
