### PR TITLE
permissions: remove usage of system_identity on service calls

### DIFF
--- a/invenio_communities/communities/services/components.py
+++ b/invenio_communities/communities/services/components.py
@@ -20,7 +20,7 @@ from invenio_records_resources.services.records.components import \
     ServiceComponent
 from marshmallow.exceptions import ValidationError
 
-from ...proxies import current_communities, current_roles
+from ...proxies import current_roles
 from ...utils import on_membership_change
 
 
@@ -166,6 +166,8 @@ class OwnershipComponent(ServiceComponent):
             "id": str(identity.id),
         }
         self.service.members.add(
+            # the user is not yet owner of the community (is being added)
+            # therefore we cannot use `identity`
             system_identity,
             record.id,
             {"members": [member], "role": current_roles.owner_role.name},
@@ -178,7 +180,7 @@ class OwnershipComponent(ServiceComponent):
 
 class FeaturedCommunityComponent(ServiceComponent):
     """Service component for featured community integration."""
-    
+
     def featured_create(self, identity, data=None, record=None, **kwargs):
         if(record.access.visibility != "public"):
             raise ValidationError(

--- a/invenio_communities/members/services/request.py
+++ b/invenio_communities/members/services/request.py
@@ -21,6 +21,11 @@ def service():
 #
 # Actions
 #
+# All actions use `system_identity` and not the `identity` param, because
+# the permission check happens at the request service (`execute_action`) level
+# before reaching these components and therefore the check is not needed.
+# These actions will assert the identity is `system identity`, which cannot
+# be obtained as a user.
 class AcceptAction(actions.AcceptAction):
     """Accept action."""
 

--- a/invenio_communities/views/communities.py
+++ b/invenio_communities/views/communities.py
@@ -11,9 +11,7 @@
 from flask import current_app, g, render_template
 from flask_babelex import lazy_gettext as _
 from flask_login import login_required
-from invenio_access.permissions import system_identity
 from invenio_records_resources.services.errors import PermissionDeniedError
-from invenio_requests.proxies import current_requests_service
 from invenio_vocabularies.proxies import current_service as vocabulary_service
 
 from .decorators import pass_community, pass_community_logo
@@ -74,7 +72,7 @@ def communities_settings(community=None, logo=None, pid_value=None):
         ['update', 'read', 'search_requests', 'search_invites']
     )
     types = vocabulary_service.read_all(
-        system_identity,
+        g.identity,
         fields=["id", "title"],
         type="communitytypes",
         max_records=10


### PR DESCRIPTION
- closes https://github.com/inveniosoftware/invenio-communities/issues/607

Since all the occurrences happen at _views_ level it is accepted to access the `g` object. The `current_user` does not provide an identity (it provides `id` and `roles`) and we would need to build the identity from it, which is already stored in `g.identity`.