### PR TITLE
invitations: clear search error state on success

### DIFF
--- a/invenio_communities/assets/semantic-ui/js/invenio_communities/members/invitations/invitationsModal/MemberSearchBar.js
+++ b/invenio_communities/assets/semantic-ui/js/invenio_communities/members/invitations/invitationsModal/MemberSearchBar.js
@@ -115,6 +115,7 @@ export class MembersSearchBar extends Component {
       this.setState({
         isFetching: false,
         suggestions: suggestions.data.hits.hits,
+        error: false,
       });
     } catch (e) {
       console.error(e);


### PR DESCRIPTION
Now clear the search bar error state when a following request is successful

closes https://github.com/inveniosoftware/invenio-communities/issues/612


![Screenshot from 2022-05-09 13-53-34](https://user-images.githubusercontent.com/55200060/167404705-02fea950-2b46-4b65-bdee-c3ef52dcd295.png)

![Screenshot from 2022-05-09 13-53-40](https://user-images.githubusercontent.com/55200060/167404704-4c0d56d1-bc9e-40e3-87c2-607ae9f263de.png)
