### PR TITLE
members: display clear empty results messages

### DIFF
--- a/invenio_communities/assets/semantic-ui/js/invenio_communities/members/members/components/MembersEmptyResults.js
+++ b/invenio_communities/assets/semantic-ui/js/invenio_communities/members/members/components/MembersEmptyResults.js
@@ -1,0 +1,40 @@
+import React, { Component } from "react";
+import { Button, Header, Icon, Segment } from "semantic-ui-react";
+import { withState } from "react-searchkit";
+import { i18next } from "@translations/invenio_communities/i18next";
+
+class MembersEmptyResults extends Component {
+  render() {
+    const {
+      resetQuery,
+      extraContent,
+      queryString,
+      currentQueryState,
+      currentResultsState,
+    } = this.props;
+
+    const isEmptyPageAfterSearch = currentQueryState.page < 0;
+    const isEmptyPage =
+      currentQueryState.page === 1 && currentResultsState.data.total === 0;
+
+    return (
+      <Segment placeholder textAlign="center">
+        <Header icon>
+          <Icon name={isEmptyPage ? "users" : "search"} />
+          {isEmptyPage && i18next.t("This community has no public members.")}
+          {isEmptyPageAfterSearch && i18next.t("No matching members found.")}
+        </Header>
+        {queryString && <em>Current search "{queryString}"</em>}
+        <br />
+        {isEmptyPageAfterSearch && (
+          <Button primary onClick={() => resetQuery()}>
+            Clear query
+          </Button>
+        )}
+        {extraContent}
+      </Segment>
+    );
+  }
+}
+
+export default withState(MembersEmptyResults);

--- a/invenio_communities/assets/semantic-ui/js/invenio_communities/members/members/public_view/index.js
+++ b/invenio_communities/assets/semantic-ui/js/invenio_communities/members/members/public_view/index.js
@@ -14,6 +14,7 @@ import { MembersResults } from "../components/MembersResult";
 import { MembersResultsGridItem } from "../components/MembersResultsGridItem";
 import { PublicMembersResultsContainer } from "./PublicMembersResultContainer";
 import { PublicMembersSearchLayout } from "./PublicMembersSearchLayout";
+import MembersEmptyResults from "../components/MembersEmptyResults";
 
 const defaultComponents = {
   "ResultsList.item": PublicMembersResultsItem,
@@ -22,6 +23,7 @@ const defaultComponents = {
   "SearchBar.element": MembersSearchBarElement,
   "SearchApp.results": MembersResults,
   "ResultsList.container": PublicMembersResultsContainer,
+  "EmptyResults.element": MembersEmptyResults,
 };
 
 // Auto-initialize search app


### PR DESCRIPTION
if there are no public members or no members found after a search, a clear message will be displayed to the user now.

closes https://github.com/inveniosoftware/invenio-communities/issues/586

![Screenshot from 2022-05-10 10-50-22](https://user-images.githubusercontent.com/55200060/167590173-3e00a60d-cf99-4375-ba3f-87cac34fa545.png)
![Screenshot from 2022-05-10 10-49-46](https://user-images.githubusercontent.com/55200060/167590310-e838df13-5e50-4467-a247-5c877b95763c.png)


