### PR TITLE
communities: add field name to service ValidationError

### DIFF
--- a/invenio_communities/members/services/service.py
+++ b/invenio_communities/members/services/service.py
@@ -378,11 +378,11 @@ class MemberService(RecordService):
 
     @unit_of_work()
     def update(
-        self, 
-        identity, 
-        community_id, 
-        data, 
-        uow=None, 
+        self,
+        identity,
+        community_id,
+        data,
+        uow=None,
         refresh=False
     ):
         """Bulk update.
@@ -422,7 +422,8 @@ class MemberService(RecordService):
             if not self.record_cls.has_members(
                     community_id, role=current_roles.owner_role.name):
                 raise ValidationError(
-                    _("A community must have at least one owner.")
+                    _("A community must have at least one owner."),
+                    field_name="members",
                 )
 
         if refresh:
@@ -511,7 +512,8 @@ class MemberService(RecordService):
         if not self.record_cls.has_members(
                 community_id, role=current_roles.owner_role.name):
             raise ValidationError(
-                _("A community must have at least one owner.")
+                _("A community must have at least one owner."),
+                field_name="members",
             )
 
         return True


### PR DESCRIPTION
- closes https://github.com/inveniosoftware/invenio-communities/issues/622

The following is a screenshot of how it looks now. Having a custom field name `members` does not seem ideal. However, any other type of fix requires a lot of custom logic and changes to the `ErrorMessage` component that might have wider effects.

![Screenshot 2022-05-10 at 10 50 20](https://user-images.githubusercontent.com/6756943/167591201-9bef5562-cb48-43fc-b7fe-0c1116e1c8c7.png)

Note: there are many other occurences of `ValidationError`s without a `field_name` accross the code base. Shall we open an issue to investigate and fix them? Having a `field_name` is a good practice (since is a Marshmallow exception) because otherwise it defaults to root `_schema`.

