### PR TITLE
frontpage: add see-all link to my communities section

### DIFF
--- a/invenio_communities/templates/semantic-ui/invenio_communities/frontpage.html
+++ b/invenio_communities/templates/semantic-ui/invenio_communities/frontpage.html
@@ -52,7 +52,12 @@
 </div>
 <div class="ui container communities-frontpage rel-mt-3 rel-mb-2">
   {% if current_user.is_authenticated %}
-    <h2 class="ui header">{{_('My communities')}}</h2>
+    <div class="flex">
+      <h2 class="ui header mb-0">{{_('My communities')}}</h2>
+      <a class="align-self-center rel-ml-1" href="{{url_for('invenio_app_rdm_users.communities')}}">
+        {{ _('See all')}}
+      </a>
+    </div>
     <div class="ui divider hidden"></div>
     <div id="user-communities" class="rel-mb-2"></div>
   {% endif %}


### PR DESCRIPTION
Added "see all" link to "My communities" section as not all communities are listed (and there is no pagination)

## Screenshot
![Screenshot 2022-05-10 at 16 41 12](https://user-images.githubusercontent.com/21052053/167655589-934fbb67-3999-4211-b464-a15178d50e53.png)

