### PR TITLE
508 backend communities permission cachingidentity loading

### DIFF
--- a/invenio_communities/members/services/components.py
+++ b/invenio_communities/members/services/components.py
@@ -6,9 +6,10 @@
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
+"""Members Components."""
+
 from flask_principal import Identity
-from invenio_records_resources.services.records.components import \
-    ServiceComponent
+from invenio_records_resources.services.records.components import ServiceComponent
 
 from invenio_communities.members.records.api import MemberMixin
 
@@ -20,39 +21,35 @@ class CommunityMemberCachingComponent(ServiceComponent):
 
     def _member_changed(self, member):
         """Call caching membership change function for user."""
-
         # TODO: relevant for groups as well?
-        if (isinstance(member, MemberMixin)):
+        if isinstance(member, MemberMixin):
             if not member.user_id:
                 return
             user_id = member.user_id
-        elif (isinstance(member, dict)):
+        elif isinstance(member, dict):
             if member.get("type") != "user":
                 return
             user_id = member["id"]
         else:
             raise TypeError(
-                "Member must be 'MemberMixin' or 'dict' but was {type}"
-                .format(type=type(member))
+                "Member must be 'MemberMixin' or 'dict' but was {type}".format(
+                    type=type(member)
+                )
             )
 
         on_membership_change(Identity(user_id))
-
 
     def accept_invite(self, identity, record=None, data=None, **kwargs):
         """On accept invite."""
         self._member_changed(record)
 
-
     def members_add(self, identity, record=None, data=None, **kwargs):
         """On member add (only for groups)."""
         self._member_changed(record)
 
-
     def members_delete(self, identity, record=None, data=None, **kwargs):
         """On member delete."""
         self._member_changed(record)
-
 
     def members_update(self, identity, record=None, data=None, **kwargs):
         """On member update."""

--- a/invenio_communities/members/services/components.py
+++ b/invenio_communities/members/services/components.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2022 Graz University of Technology.
+#
+# Invenio is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+from flask_principal import Identity
+from invenio_records_resources.services.records.components import \
+    ServiceComponent
+
+from invenio_communities.members.records.api import MemberMixin
+
+from ...utils import on_membership_change
+
+
+class CommunityMemberCachingComponent(ServiceComponent):
+    """Service component for community member caching."""
+
+    def _member_changed(self, member):
+        """Call caching membership change function for user."""
+
+        # TODO: relevant for groups as well?
+        if (isinstance(member, MemberMixin)):
+            if not member.user_id:
+                return
+            user_id = member.user_id
+        elif (isinstance(member, dict)):
+            if member.get("type") != "user":
+                return
+            user_id = member["id"]
+        else:
+            raise TypeError(
+                "Member must be 'MemberMixin' or 'dict' but was {type}"
+                .format(type=type(member))
+            )
+
+        on_membership_change(Identity(user_id))
+
+
+    def accept_invite(self, identity, record=None, data=None, **kwargs):
+        """On accept invite."""
+        self._member_changed(record)
+
+
+    def members_add(self, identity, record=None, data=None, **kwargs):
+        """On member add (only for groups)."""
+        self._member_changed(record)
+
+
+    def members_delete(self, identity, record=None, data=None, **kwargs):
+        """On member delete."""
+        self._member_changed(record)
+
+
+    def members_update(self, identity, record=None, data=None, **kwargs):
+        """On member update."""
+        self._member_changed(record)

--- a/invenio_communities/members/services/config.py
+++ b/invenio_communities/members/services/config.py
@@ -19,10 +19,14 @@ from invenio_records_resources.services.records.queryparser import (
     SearchFieldTransformer,
 )
 
+from invenio_records_resources.services.records.components import \
+    MetadataComponent
+
 from ...communities.records.api import Community
 from ...permissions import CommunityPermissionPolicy
 from ..records import Member
 from . import facets
+from .components import CommunityMemberCachingComponent
 from .schemas import MemberEntitySchema
 
 
@@ -167,4 +171,12 @@ class MemberServiceConfig(RecordServiceConfig):
     links_item = {}
 
     # ResultList configurations
-    links_search = pagination_links("{+api}/communities/{community_id}/members{?args*}")
+    links_search = pagination_links(
+        "{+api}/communities/{community_id}/members{?args*}"
+    )
+
+    # Service components
+    components = [
+        MetadataComponent,
+        CommunityMemberCachingComponent,
+    ]

--- a/invenio_communities/members/services/config.py
+++ b/invenio_communities/members/services/config.py
@@ -14,13 +14,11 @@ from invenio_records_resources.services import (
     SearchOptions,
     pagination_links,
 )
+from invenio_records_resources.services.records.components import MetadataComponent
 from invenio_records_resources.services.records.queryparser import (
     QueryParser,
     SearchFieldTransformer,
 )
-
-from invenio_records_resources.services.records.components import \
-    MetadataComponent
 
 from ...communities.records.api import Community
 from ...permissions import CommunityPermissionPolicy
@@ -171,9 +169,7 @@ class MemberServiceConfig(RecordServiceConfig):
     links_item = {}
 
     # ResultList configurations
-    links_search = pagination_links(
-        "{+api}/communities/{community_id}/members{?args*}"
-    )
+    links_search = pagination_links("{+api}/communities/{community_id}/members{?args*}")
 
     # Service components
     components = [

--- a/invenio_communities/members/services/service.py
+++ b/invenio_communities/members/services/service.py
@@ -524,7 +524,7 @@ class MemberService(RecordService):
 
         # Run components
         self.run_components(
-            'members_update',
+            "members_update",
             identity,
             record=member,
             errors=None,
@@ -567,7 +567,7 @@ class MemberService(RecordService):
             )
             # Run components
             self.run_components(
-                'members_delete',
+                "members_delete",
                 identity,
                 record=m,
                 errors=None,
@@ -597,7 +597,7 @@ class MemberService(RecordService):
         # TODO: recompute permissions for member.
         # Run components
         self.run_components(
-            'accept_invite',
+            "accept_invite",
             identity,
             record=member,
             errors=None,

--- a/invenio_communities/utils.py
+++ b/invenio_communities/utils.py
@@ -11,7 +11,7 @@
 from invenio_cache import current_cache
 
 from .generators import CommunityRoleNeed
-from .members.records.api import Member
+from .proxies import current_communities
 
 
 def load_community_needs(identity):
@@ -42,16 +42,15 @@ def load_community_needs(identity):
     # entities and combine it into a single list.
 
     # Currently, only users are supported (no roles or system roles)
-    # cache_key = identity_cache_key(identity)
-    # community_roles = current_cache.get(cache_key)
-    # if community_roles is None:
-    #         community_roles = Member.get_memberships(identity)
-    #         current_cache.set(cache_key, community_roles, timeout=24*3600)
-
-    # TODO: Fix caching issues
+    cache_key = identity_cache_key(identity)
+    community_roles = current_cache.get(cache_key)
+    if community_roles is None:
+            # aka Member.get_memberships(identity)
+            community_roles = current_communities.service.members.config.record_cls.get_memberships(identity)
+            current_cache.set(cache_key, community_roles, timeout=24*3600)
 
     # Add community needs to identity
-    for c_id, role in Member.get_memberships(identity):
+    for c_id, role in community_roles:
         identity.provides.add(CommunityRoleNeed(c_id, role))
 
 

--- a/invenio_communities/utils.py
+++ b/invenio_communities/utils.py
@@ -45,9 +45,13 @@ def load_community_needs(identity):
     cache_key = identity_cache_key(identity)
     community_roles = current_cache.get(cache_key)
     if community_roles is None:
-            # aka Member.get_memberships(identity)
-            community_roles = current_communities.service.members.config.record_cls.get_memberships(identity)
-            current_cache.set(cache_key, community_roles, timeout=24*3600)
+        # aka Member.get_memberships(identity)
+        community_roles = (
+            current_communities.service.members.config.record_cls.get_memberships(
+                identity
+            )
+        )
+        current_cache.set(cache_key, community_roles, timeout=24 * 3600)
 
     # Add community needs to identity
     for c_id, role in community_roles:

--- a/tests/communities/test_services.py
+++ b/tests/communities/test_services.py
@@ -11,10 +11,10 @@
 import time
 from copy import deepcopy
 from datetime import datetime, timedelta
-from invenio_cache import current_cache
 
 import pytest
 from invenio_access.permissions import system_identity
+from invenio_cache import current_cache
 from invenio_records_resources.services.errors import PermissionDeniedError
 from marshmallow import ValidationError
 

--- a/tests/communities/test_services.py
+++ b/tests/communities/test_services.py
@@ -327,6 +327,7 @@ def test_search_user(
     members,
     new_user,
 ):
+    current_cache.clear()
     owner = members["owner"]
     reader = members["reader"]
 

--- a/tests/communities/test_services.py
+++ b/tests/communities/test_services.py
@@ -11,6 +11,7 @@
 import time
 from copy import deepcopy
 from datetime import datetime, timedelta
+from invenio_cache import current_cache
 
 import pytest
 from invenio_access.permissions import system_identity
@@ -289,7 +290,6 @@ def test_update_featured(community_service, comm):
             featured_id=past_entry["id"],
             data={},
         ).to_dict()
-        print(x)
 
     community_service.featured_delete(
         identity=system_identity,

--- a/tests/members/test_members_components.py
+++ b/tests/members/test_members_components.py
@@ -1,0 +1,117 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2022 Graz University of Technology.
+#
+# Invenio-Communities is free software; you can redistribute it and/or modify
+# it under the terms of the MIT License; see LICENSE file for more details.
+
+"""Test components."""
+
+from invenio_cache import current_cache
+from invenio_access.permissions import system_identity
+from invenio_communities.utils import identity_cache_key
+
+
+def test_accept_invite_cache_clear(requests_service, invite_request_id, invite_user, db, es_clear):
+    """Test that the community member cached entries are cleared."""
+    current_cache.clear()
+    cache_key = identity_cache_key(invite_user.identity)
+
+    invite_user.refresh()
+    community_roles = current_cache.get(cache_key)
+    assert len(community_roles) == 0
+
+    # cached entry should be cleared on accept_invite
+    requests_service.execute_action(
+        invite_user.identity, invite_request_id, 'accept')
+    community_roles = current_cache.get(cache_key)
+    assert community_roles == None
+    invite_user.refresh()
+    community_roles = current_cache.get(cache_key)
+    assert len(community_roles) == 1
+    
+def test_member_delete_cache_clear(member_service, community, new_user, db, es_clear):
+    """Test that the community member cached entries are cleared."""
+    current_cache.clear()
+    cache_key = identity_cache_key(new_user.identity)
+
+    new_user.refresh()
+    community_roles = current_cache.get(cache_key)
+    assert len(community_roles) == 0
+
+    # cached entry should be cleared on add
+    add_data = {
+        "members": [{"type": "user", "id": str(new_user.id)}],
+        "role": "reader",
+    }
+    member_service.add(system_identity, community._record.id, add_data)
+    community_roles = current_cache.get(cache_key)
+    assert community_roles == None
+    new_user.refresh()
+    community_roles = current_cache.get(cache_key)
+    assert len(community_roles) == 1
+
+    # cached entry should be cleared on delete
+    delete_data = {
+        "members": [{"type": "user", "id": str(new_user.id)}],
+    }
+    member_service.delete(system_identity, community._record.id, delete_data)
+    community_roles = current_cache.get(cache_key)
+    assert community_roles == None
+    new_user.refresh()
+    community_roles = current_cache.get(cache_key)
+    assert len(community_roles) == 0
+
+def test_member_add_cache_clear(member_service, community, new_user, db, es_clear):
+    """Test that the community member cached entries are cleared."""
+    current_cache.clear()
+    cache_key = identity_cache_key(new_user.identity)
+
+    new_user.refresh()
+    community_roles = current_cache.get(cache_key)
+    assert len(community_roles) == 0
+
+    # cached entry should be cleared on add
+    add_data = {
+        "members": [{"type": "user", "id": str(new_user.id)}],
+        "role": "reader",
+    }
+    member_service.add(system_identity, community._record.id, add_data)
+    community_roles = current_cache.get(cache_key)
+    assert community_roles == None
+    new_user.refresh()
+    community_roles = current_cache.get(cache_key)
+    assert len(community_roles) == 1
+
+
+def test_member_update_cache_clear(member_service, community, new_user, db, es_clear):
+    """Test that the community member cached entries are cleared."""
+    current_cache.clear()
+    cache_key = identity_cache_key(new_user.identity)
+
+    new_user.refresh()
+    community_roles = current_cache.get(cache_key)
+    assert len(community_roles) == 0
+
+    # cached entry should be cleared on add
+    add_data = {
+        "members": [{"type": "user", "id": str(new_user.id)}],
+        "role": "reader",
+    }
+    member_service.add(system_identity, community._record.id, add_data)
+    community_roles = current_cache.get(cache_key)
+    assert community_roles == None
+    new_user.refresh()
+    community_roles = current_cache.get(cache_key)
+    assert len(community_roles) == 1
+
+    update_data = {
+        "members": [{"type": "user", "id": str(new_user.id)}],
+        "role": "reader",
+    }
+    member_service.update(system_identity, community._record.id, update_data)
+    community_roles = current_cache.get(cache_key)
+    assert community_roles == None
+    new_user.refresh()
+    community_roles = current_cache.get(cache_key)
+    assert len(community_roles) == 1

--- a/tests/members/test_members_components.py
+++ b/tests/members/test_members_components.py
@@ -119,3 +119,29 @@ def test_member_update_cache_clear(member_service, community, new_user, db, es_c
     new_user.refresh()
     community_roles = current_cache.get(cache_key)
     assert len(community_roles) == 1
+
+
+def test_group_add_cache_clear(
+    member_service, restricted_community, admin, db, es_clear
+):
+    """Test that the community member cached entries are cleared on group add."""
+    current_cache.clear()
+    cache_key = identity_cache_key(admin.identity)
+
+    admin.refresh()
+    community_roles = current_cache.get(cache_key)
+    assert len(community_roles) == 0
+
+    data = {
+        "members": [{"type": "group", "id": "admin-access"}],
+        "role": "reader",
+    }
+
+    member_service.add(system_identity, restricted_community._record.id, data)
+    # cached entry should be cleared for group members
+    community_roles = current_cache.get(cache_key)
+    assert community_roles == None
+
+    admin.refresh()
+    community_roles = current_cache.get(cache_key)
+    assert len(community_roles) == 1

--- a/tests/members/test_members_components.py
+++ b/tests/members/test_members_components.py
@@ -7,12 +7,15 @@
 
 """Test components."""
 
-from invenio_cache import current_cache
 from invenio_access.permissions import system_identity
+from invenio_cache import current_cache
+
 from invenio_communities.utils import identity_cache_key
 
 
-def test_accept_invite_cache_clear(requests_service, invite_request_id, invite_user, db, es_clear):
+def test_accept_invite_cache_clear(
+    requests_service, invite_request_id, invite_user, db, es_clear
+):
     """Test that the community member cached entries are cleared."""
     current_cache.clear()
     cache_key = identity_cache_key(invite_user.identity)
@@ -22,14 +25,14 @@ def test_accept_invite_cache_clear(requests_service, invite_request_id, invite_u
     assert len(community_roles) == 0
 
     # cached entry should be cleared on accept_invite
-    requests_service.execute_action(
-        invite_user.identity, invite_request_id, 'accept')
+    requests_service.execute_action(invite_user.identity, invite_request_id, "accept")
     community_roles = current_cache.get(cache_key)
     assert community_roles == None
     invite_user.refresh()
     community_roles = current_cache.get(cache_key)
     assert len(community_roles) == 1
-    
+
+
 def test_member_delete_cache_clear(member_service, community, new_user, db, es_clear):
     """Test that the community member cached entries are cleared."""
     current_cache.clear()
@@ -61,6 +64,7 @@ def test_member_delete_cache_clear(member_service, community, new_user, db, es_c
     new_user.refresh()
     community_roles = current_cache.get(cache_key)
     assert len(community_roles) == 0
+
 
 def test_member_add_cache_clear(member_service, community, new_user, db, es_clear):
     """Test that the community member cached entries are cleared."""

--- a/tests/members/test_members_services.py
+++ b/tests/members/test_members_services.py
@@ -12,6 +12,7 @@
 import pytest
 from invenio_access.permissions import system_identity
 from invenio_accounts.proxies import current_datastore
+from invenio_cache import current_cache
 from invenio_records_resources.services.errors import PermissionDeniedError
 from invenio_requests.records.api import RequestEvent
 from marshmallow import ValidationError
@@ -37,6 +38,7 @@ from invenio_communities.members.records.api import ArchivedInvitation, Member
 )
 def test_add_allowed(member_service, community, members, group, actor, role, db):
     """Test that the given roles CAN add a group member."""
+    current_cache.clear()
     data = {
         "members": [{"type": "group", "id": group.name}],
         "role": role,


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

closes #508 
depends on #773 (for group caching test case)

Runs the components for methods which modify users.
Reactivates permission caching for communities. A cached entry is removed on `accept_invite`, `add`, `update`, `delete`.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/best-practices/i18n/) (for relevant code).
- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines (for relevant code).
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines (for relevant code).
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines (for relevant code).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).

**Third-party code**

If you've added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
