### PR TITLE
community card: make images same size

### DIFF
--- a/invenio_communities/assets/semantic-ui/js/invenio_communities/community/frontpage.js
+++ b/invenio_communities/assets/semantic-ui/js/invenio_communities/community/frontpage.js
@@ -51,6 +51,9 @@ class CommunityCard extends Component {
     return (
       <Card fluid href={`/communities/${this.props.community.slug}`}>
         <Image
+          wrapped
+          centered
+          ui={false}
           src={this.props.community.links.logo}
           fallbackSrc={this.props.defaultLogo}
           loadFallbackFirst={true}


### PR DESCRIPTION
**Needs PR** https://github.com/inveniosoftware/invenio-app-rdm/pull/1542

Makes community images same size in the front page cards container.

## Screenshots
<img width="328" alt="Screenshot 2022-05-11 at 10 08 34" src="https://user-images.githubusercontent.com/21052053/167801835-7c8e1572-2836-4e74-b2a3-2054824f5335.png">
<img width="826" alt="Screenshot 2022-05-11 at 10 08 24" src="https://user-images.githubusercontent.com/21052053/167801850-b2aa84d8-a099-4d82-bc8e-5a74c3d5aa20.png">
<img width="1720" alt="Screenshot 2022-05-11 at 10 08 15" src="https://user-images.githubusercontent.com/21052053/167801854-dad012d7-2baa-44db-a2b3-212049a365ea.png">
<img width="1328" alt="Screenshot 2022-05-11 at 10 08 07" src="https://user-images.githubusercontent.com/21052053/167801863-a675f138-4ac5-431c-a478-2c36e5418bd7.png">

