### PR TITLE
members: move role information to separate message

### DIFF
--- a/tests/members/test_members_resource.py
+++ b/tests/members/test_members_resource.py
@@ -127,7 +127,10 @@ def test_invite(client, headers, community_id, owner, new_user_data, db):
     request_id=r.json["hits"]["hits"][0]["request"]["id"]
     r = client.get(f"/requests/{request_id}/timeline", headers=headers)
     r.status_code == 200
+    assert r.json["hits"]["total"] == 2  # role message + invite message
     assert r.json["hits"]["hits"][0]["payload"]["content"] == \
+        "You will join as \"Reader\""
+    assert r.json["hits"]["hits"][1]["payload"]["content"] == \
         new_user_data["message"]
 
 

--- a/tests/members/test_members_services.py
+++ b/tests/members/test_members_services.py
@@ -276,8 +276,10 @@ def test_invite_view_request(
         request_id=res["hits"]["hits"][0]["id"],
     ).to_dict()
     hits = res['hits']
-    assert hits['total'] == 1
-    assert hits["hits"][0]["payload"]["content"] == "Welcome to the club!"
+    assert hits['total'] == 2  # role + invitation
+    assert hits["hits"][0]["payload"]["content"] == \
+        "You will join as \"Reader\""
+    assert hits["hits"][1]["payload"]["content"] == "Welcome to the club!"
 
 
 #


### PR DESCRIPTION
- closes #557 

How it looks:

![Screenshot 2022-05-11 at 10 36 57](https://user-images.githubusercontent.com/6756943/167810686-a0f5a950-4209-4545-912a-18268f60e0cb.png)

Wokflow:

1. Note the capitalization issue
2. Is there a better phrasing than "You would join as..."

https://user-images.githubusercontent.com/6756943/167810741-4839730e-94d7-4aaf-90e5-9ecaac039799.mov


