### PR TITLE
parent facet value: change arrow icon to button for a11y

### DIFF
--- a/invenio_communities/assets/semantic-ui/js/invenio_communities/details_search/components.js
+++ b/invenio_communities/assets/semantic-ui/js/invenio_communities/details_search/components.js
@@ -225,7 +225,12 @@ export const CommunityParentFacetValue = ({
         className="facet-wrapper parent"
       >
         <List.Content className="facet-wrapper">
-          <Icon name="angle right" onClick={() => setIsActive(!isActive)} />
+          <Button
+            icon="angle right"
+            className="transparent"
+            onClick={() => setIsActive(!isActive)}
+            aria-label={i18next.t("Show all sub facets of ") + bucket.label || keyField}
+          />
           <Checkbox
             label={bucket.label || keyField}
             id={`${keyField}-facet-checkbox`}

--- a/invenio_communities/assets/semantic-ui/js/invenio_communities/requests/requests.js
+++ b/invenio_communities/assets/semantic-ui/js/invenio_communities/requests/requests.js
@@ -95,7 +95,12 @@ export const ParentFacetValue = ({
         className="facet-wrapper parent"
       >
         <List.Content className="facet-wrapper">
-          <Icon name="angle right" onClick={() => setIsActive(!isActive)} />
+          <Button
+            icon="angle right"
+            className="transparent"
+            onClick={() => setIsActive(!isActive)}
+            aria-label={i18next.t("Show all sub facets of ") + bucket.label || keyField}
+          />
           <Checkbox
             label={bucket.label || keyField}
             id={`${keyField}-facet-checkbox`}


### PR DESCRIPTION
Closes https://github.com/inveniosoftware/invenio-app-rdm/issues/1547
**Related PR** https://github.com/inveniosoftware/invenio-app-rdm/pull/1563

Changed the arrow icon to <Button/> to ensure that the icon is accessible by keyboard and with a screen reader.

Tested with VoiceOver on Mac.