### PR TITLE
community header: layout improvements

### DIFF
--- a/invenio_communities/templates/semantic-ui/invenio_communities/details/header.html
+++ b/invenio_communities/templates/semantic-ui/invenio_communities/details/header.html
@@ -12,47 +12,68 @@
 <div class="ui container fluid page-subheader-outer with-submenu rel-pt-2">
   <div class="ui container relaxed grid page-subheader">
     <div class="row pb-0">
-      <div class="sixteen wide mobile five wide tablet two wide computer column">
-        <div class="ui rounded fluid image community-image rel-mb-2">
+      <div class="sixteen wide mobile sixteen wide tablet thirteen wide computer column">
+
+        <div class="ui rounded image community-image mt-5 rel-mr-2 left-floated">
           <img src="{{ community.links.logo }}" alt="Community logo" onerror="this.onerror=null;this.src='/static/images/square-placeholder.png';"/>
         </div>
-      </div>
 
-      <div class="sixteen wide mobile eleven wide tablet eleven wide computer column rel-mb-2">
-        <h2 class="ui header">{{ community.metadata.title }}</h2>
-        <div class="rel-mb-2">
-          {{ truncate_text(community.metadata.description) }}
-        </div>
+        <div>
+          <h2 class="ui header">{{ community.metadata.title }}</h2>
 
-        {% if community.metadata.type is defined %}
-        <div class="mt-5">
-          <i class="tag icon" aria-hidden="true"></i>
-          <div class="ui label small grey type-label">
-            {{ community.metadata.type.title.en }}
+          <div>
+            {% if community.metadata.website %}
+            <div class="inline-computer mt-5 rel-mr-1">
+              <i class="linkify icon" aria-hidden="true"></i>
+              <a href="{{community.metadata.website}}">
+                {{community.metadata.website}}
+              </a>
+            </div>
+            {% endif %}
+
+            {% if community.metadata.type is defined %}
+            <div class="inline-computer mt-5 rel-mr-1">
+              <i class="tag icon" aria-hidden="true"></i>
+              <span class="label label-keyword">
+                {{ community.metadata.type.title.en }}
+              </span>
+            </div>
+            {% endif %}
+
+            {% if community.metadata.organizations %}
+            <div class="inline-computer mt-5 rel-mr-1">
+              <i class="building outline icon" aria-hidden="true"></i>
+              <span class="label label-keyword">{{ community.metadata.organizations| map(attribute='name') | join(', ') }}</span>
+            </div>
+            {% endif %}
           </div>
-        </div>
-        {% endif %}
 
-        {% if community.metadata.website %}
-        <div class="mt-5">
-          <i class="linkify icon" aria-hidden="true"></i>
-          <a href="{{community.metadata.website}}">
-            {{community.metadata.website}}
-          </a>
+          {% if community.metadata.description %}
+            <div class="ui accordion mt-5">
+              <div id="description-accordion"
+                   role="button"
+                   aria-controls="community-description"
+                   aria-expanded="false"
+                   tabindex="0"
+                   class="title"
+              >
+                {{ _("About this community") }}
+                <i class="icon right chevron pl-5"></i>
+              </div>
+              <div id="community-description"
+                   aria-labelledby="description-accordion"
+                   class="content rel-mb-2"
+              >
+                {{ community.metadata.description }}
+              </div>
+            </div>
+          {% endif %}
         </div>
-        {% endif %}
-
-        {% if community.metadata.organizations %}
-        <div class="mt-5">
-          <i class="building outline icon" aria-hidden="true"></i>
-          <span class="label label-keyword">{{ community.metadata.organizations| map(attribute='name') | join(', ') }}</span>
-        </div>
-        {% endif %}
       </div>
 
-      <div class="sixteen wide mobile sixteen wide tablet three wide computer right aligned bottom aligned column">
+      <div class="sixteen wide mobile sixteen wide tablet three wide computer right aligned middle aligned column">
         <a href="/uploads/new?community={{ community.id }}"
-            class="ui positive button labeled icon">
+            class="ui positive button labeled icon rel-mt-1">
           <i class="plus icon" aria-hidden="true"></i>
           {{ _("New upload") }}
         </a>


### PR DESCRIPTION
**Needs** https://github.com/inveniosoftware/invenio-app-rdm/pull/1574

Reduced the amount of space needed for the header content.
- Moved description to accordion
- Changed details listing to be inline on computer (needs PR mentioned above - use of `.flex` does not solve the issue, as this class does not break the content on smaller screens.)
- Made logo slightly smaller on tablet

## Screenshots
<img width="1639" alt="Screenshot 2022-05-16 at 14 43 20" src="https://user-images.githubusercontent.com/21052053/168595141-7387da30-1204-4412-aa4e-8c9d90555889.png">
<img width="1640" alt="Screenshot 2022-05-16 at 14 44 24" src="https://user-images.githubusercontent.com/21052053/168595231-63cddafb-611a-4fca-b1cd-4fa6dab0bfd1.png">
<img width="831" alt="Screenshot 2022-05-16 at 14 43 32" src="https://user-images.githubusercontent.com/21052053/168595163-9bb0fa4f-3cd4-4007-b977-8b73ee591a83.png">
<img width="348" alt="Screenshot 2022-05-16 at 14 11 59" src="https://user-images.githubusercontent.com/21052053/168593822-d9e2fcd4-87f2-42ac-8f13-ab08be2d115f.png">

<img width="1639" alt="Screenshot 2022-05-16 at 14 45 15" src="https://user-images.githubusercontent.com/21052053/168595437-461aae92-7909-4802-b7e6-f0480c84c1ca.png">
<img width="832" alt="Screenshot 2022-05-16 at 14 45 25" src="https://user-images.githubusercontent.com/21052053/168595459-f9b06e26-3253-4914-82f3-17e6ddfad745.png">
<img width="338" alt="Screenshot 2022-05-16 at 14 12 50" src="https://user-images.githubusercontent.com/21052053/168593807-f12b86d4-5d8c-4a7e-957a-0ad85922e73e.png">






