### PR TITLE
communities: fix searchbar behaviour

### DIFF
--- a/invenio_communities/assets/semantic-ui/js/invenio_communities/community/search.js
+++ b/invenio_communities/assets/semantic-ui/js/invenio_communities/community/search.js
@@ -22,6 +22,7 @@ import {
   ResultsPerPage,
   SearchBar,
   Sort,
+  withState,
 } from "react-searchkit";
 import {
   Button,
@@ -161,38 +162,46 @@ export const CommunitiesResults = ({
   );
 };
 
-export const CommunitiesSearchBarElement = ({
-  placeholder: passedPlaceholder,
-  queryString,
-  onInputChange,
-  executeSearch,
-}) => {
-  const placeholder = passedPlaceholder || i18next.t("Search");
-  const onBtnSearchClick = () => {
-    executeSearch();
-  };
-  const onKeyPress = (event) => {
-    if (event.key === "Enter") {
-      executeSearch();
-    }
-  };
-  return (
-    <Input
-      action={{
-        icon: "search",
-        onClick: onBtnSearchClick,
-        className: "search",
-      }}
-      fluid
-      placeholder={placeholder}
-      onChange={(event, { value }) => {
-        onInputChange(value);
-      }}
-      value={queryString}
-      onKeyPress={onKeyPress}
-    />
-  );
-};
+export const CommunitiesSearchBarElement = withState(
+  ({
+    placeholder: passedPlaceholder,
+    queryString,
+    onInputChange,
+    updateQueryState,
+    currentQueryState,
+  }) => {
+    const placeholder = passedPlaceholder || i18next.t("Search");
+
+    const onSearch = () => {
+      updateQueryState({ ...currentQueryState, queryString });
+    };
+    const onBtnSearchClick = () => {
+      onSearch();
+    };
+    const onKeyPress = (event) => {
+      if (event.key === "Enter") {
+        onSearch();
+      }
+    };
+
+    return (
+      <Input
+        action={{
+          icon: "search",
+          onClick: onBtnSearchClick,
+          className: "search",
+        }}
+        fluid
+        placeholder={placeholder}
+        onChange={(event, { value }) => {
+          onInputChange(value);
+        }}
+        value={queryString}
+        onKeyPress={onKeyPress}
+      />
+    );
+  }
+);
 
 const CommunitiesFacets = ({ aggs, currentResultsState }) => {
   return (

--- a/invenio_communities/assets/semantic-ui/js/invenio_communities/requests/requests.js
+++ b/invenio_communities/assets/semantic-ui/js/invenio_communities/requests/requests.js
@@ -50,12 +50,17 @@ export const RecordSearchBarElement = withState(
     currentQueryState,
   }) => {
     const placeholder = passedPlaceholder || i18next.t("Search");
+
+    const onSearch = () => {
+      updateQueryState({ ...currentQueryState, queryString });
+    };
+
     const onBtnSearchClick = () => {
-      updateQueryState({ ...currentQueryState, filters: [] });
+      onSearch();
     };
     const onKeyPress = (event) => {
       if (event.key === "Enter") {
-        updateQueryState({ ...currentQueryState, filters: [] });
+        onSearch();
       }
     };
     return (


### PR DESCRIPTION
search bar now correctly triggers a search event in the communities search page and now correctly holds the filter state and query string while switching between modes
in the communities requests page

closes https://github.com/inveniosoftware/invenio-communities/issues/695
closes https://github.com/inveniosoftware/invenio-communities/issues/697

![Screenshot from 2022-06-01 14-44-31](https://user-images.githubusercontent.com/55200060/171407961-fd30f83e-aa84-4020-8ab8-50ca3b6db6c2.png)
![Screenshot from 2022-06-01 14-44-20](https://user-images.githubusercontent.com/55200060/171407968-7fd92f99-f3a3-403a-a9e1-9e214cf0a672.png)
![Screenshot from 2022-06-01 14-44-13](https://user-images.githubusercontent.com/55200060/171407973-b6a192fc-b743-49ba-8ac5-cc254778b31b.png)


