### PR TITLE
members: reserves space for success/error icon

### DIFF
--- a/invenio_communities/assets/semantic-ui/js/invenio_communities/members/components/ActionDropdown.js
+++ b/invenio_communities/assets/semantic-ui/js/invenio_communities/members/components/ActionDropdown.js
@@ -80,7 +80,7 @@ class ActionDropdown extends Component {
             fluid={fluid}
             floating
           />
-          <div className="ml-5">
+          <div className="ml-5 action-status-container">
             {actionSuccess && (
               <SuccessIcon timeOutDelay={3000} show={actionSuccess} />
             )}


### PR DESCRIPTION
closes https://github.com/inveniosoftware/invenio-app-rdm/issues/1714

The issue was that the dropdown container width was adjusting when the icon rendered. E.g. when the icon was rendered, the dropdown container shrinked.

This fix reserves space for the success/error icon by creating a `div`. Does not reduce the dropdown size a lot and it's enough to make the whole cell static when changing the selection.