### PR TITLE
settinngs: added warning notification for file upload.

### DIFF
--- a/invenio_communities/assets/semantic-ui/js/invenio_communities/settings/profile/index.js
+++ b/invenio_communities/assets/semantic-ui/js/invenio_communities/settings/profile/index.js
@@ -8,7 +8,7 @@
  */
 
 import { i18next } from "@translations/invenio_communities/i18next";
-import { Formik } from "formik";
+import { Formik, useFormikContext } from "formik";
 import _cloneDeep from "lodash/cloneDeep";
 import _defaultsDeep from "lodash/defaultsDeep";
 import _get from "lodash/get";
@@ -40,6 +40,7 @@ import {
   Grid,
   Header,
   Icon,
+  Label,
   Message,
   Segment,
 } from "semantic-ui-react";
@@ -103,6 +104,7 @@ const removeEmptyValues = (obj) => {
 };
 
 const LogoUploader = ({ community, defaultLogo, hasLogo, onError, logoMaxSize }) => {
+  const { submitForm } = useFormikContext();
   let dropzoneParams = {
     preventDropOnDocument: true,
     onDropAccepted: async (acceptedFiles) => {
@@ -113,6 +115,7 @@ const LogoUploader = ({ community, defaultLogo, hasLogo, onError, logoMaxSize })
       try {
         const client = new CommunityApi();
         await client.updateLogo(community.id, file);
+        await submitForm();
         window.location.reload();
       } catch (error) {
         onError(error);
@@ -464,7 +467,7 @@ class CommunityProfileForm extends Component {
         validationSchema={COMMUNITY_VALIDATION_SCHEMA}
         onSubmit={this.onSubmit}
       >
-        {({ isSubmitting, isValid, handleSubmit }) => (
+        {({ isSubmitting, isValid, handleSubmit, dirty }) => (
           <Form onSubmit={handleSubmit} className="communities-profile">
             <Message
               hidden={this.state.error === ""}
@@ -702,6 +705,13 @@ class CommunityProfileForm extends Component {
                     onError={this.setGlobalError}
                     logoMaxSize={this.props.logoMaxSize}
                   />
+                  {dirty && (
+                    <Label className="helptext warning rel-mt-1 rel-ml-0">
+                      {i18next.t(
+                        "Form has unsaved changes, they will be automatically saved if a new picture is uploaded."
+                      )}
+                    </Label>
+                  )}
                 </Grid.Column>
               </Grid.Row>
               <Grid.Row className="danger-zone">


### PR DESCRIPTION
closes https://github.com/inveniosoftware/invenio-communities/issues/741

- Form is automatically submitted when the user uploads a community logo.
- Added a warning message under logo upload box.
- Message is only shown when the form is considered `dirty`, e.g. when the user edited the form.

When form is not edited yet:

![image](https://user-images.githubusercontent.com/21204744/177499444-7208cdea-b88d-4b28-b8e4-347e1c1508d3.png)


When form is dirty, e.g. edited but not saved yet: 

![image](https://user-images.githubusercontent.com/21204744/177499514-98940850-a972-4450-9ec4-79439f5d8479.png)

Note: this is not final, as other suggestions arose from discussion. E.g. displaying the same warning message in a modal when the user clicks `Upload new picture`. 
