### PR TITLE
header: added class to access-statust div to set its width to fit lab…

### DIFF
--- a/invenio_communities/assets/semantic-ui/js/invenio_communities/community/communities_items/ComputerTabletCommunitiesItem.js
+++ b/invenio_communities/assets/semantic-ui/js/invenio_communities/community/communities_items/ComputerTabletCommunitiesItem.js
@@ -20,7 +20,7 @@ export const ComputerTabletCommunitiesItem = ({ result }) => {
     : i18next.t("Restricted");
   const visibilityIcon = isPublic ? undefined : "ban";
   return (
-    <Item key={result.id} className="computer tablet only flex">
+    <Item key={result.id} className="computer tablet only flex community-item">
       <Image
         wrapped
         src={result.links.logo}

--- a/invenio_communities/assets/semantic-ui/js/invenio_communities/community/communities_items/MobileCommunitiesItem.js
+++ b/invenio_communities/assets/semantic-ui/js/invenio_communities/community/communities_items/MobileCommunitiesItem.js
@@ -20,7 +20,7 @@ export const MobileCommunitiesItem = ({ result }) => {
     : i18next.t("Restricted");
   const visibilityIcon = isPublic ? undefined : "ban";
   return (
-    <Item key={result.id} className="mobile only">
+    <Item key={result.id} className="mobile only community-item">
       <Item.Content className="centered">
         <Item.Extra className="user-communities">
           {community_type && (

--- a/invenio_communities/assets/semantic-ui/js/invenio_communities/community/frontpage.js
+++ b/invenio_communities/assets/semantic-ui/js/invenio_communities/community/frontpage.js
@@ -62,7 +62,7 @@ class CommunityCard extends Component {
         />
         <Card.Content>
           <Card.Header>
-            {_truncate(community.metadata.title, { length: 50 })}
+            {_truncate(community.metadata.title, { length: 30 })}
           </Card.Header>
           {community.metadata.description && (
             <Card.Description>

--- a/invenio_communities/templates/semantic-ui/invenio_communities/details/header.html
+++ b/invenio_communities/templates/semantic-ui/invenio_communities/details/header.html
@@ -8,6 +8,7 @@
 #}
 
 {%- from "invenio_theme/macros/truncate.html" import truncate_text %}
+{%- from "invenio_communities/details/macros/access-status-label.html" import access_status_label -%}
 
 <div class="ui container fluid page-subheader-outer with-submenu rel-pt-2 ml-0-mobile mr-0-mobile">
   <div class="ui container relaxed grid page-subheader mr-0-mobile ml-0-mobile">
@@ -22,14 +23,17 @@
           />
         </div>
 
+        {% if community.access.visibility == 'restricted' %}
+          <div class="rel-mb-2 mobile only">
+            {{ access_status_label() }}
+          </div>
+        {% endif %}
+
           <div class="flex rel-mb-1">
             <h2 class="ui header mb-0">{{ community.metadata.title }}</h2>
             {% if community.access.visibility == 'restricted' %}
-              <div class="rel-ml-1">
-                <span class="ui label small access-status restricted" title="{{ _('Community visibility') }}"
-                  data-tooltip="{{ _('The community is restricted to users with access.') }}" data-inverted="">
-                  <i class="icon ban" aria-hidden="true"></i> {{ _("Restricted") }}
-                </span>
+              <div class="rel-ml-1 computer only tablet only">
+                {{ access_status_label() }}
               </div>
             {% endif %}
           </div>

--- a/invenio_communities/templates/semantic-ui/invenio_communities/details/macros/access-status-label.html
+++ b/invenio_communities/templates/semantic-ui/invenio_communities/details/macros/access-status-label.html
@@ -1,0 +1,11 @@
+{% macro access_status_label() %}
+  <div
+    class="ui label small access-status restricted"
+    title="{{ _('Community visibility') }}"
+    data-tooltip="{{ _('The community is restricted to users with access.') }}"
+    data-inverted=""
+    data-position="top right"
+  >
+    <i class="icon ban" aria-hidden="true"></i> {{ _("Restricted") }}
+  </div>
+{% endmacro %}


### PR DESCRIPTION
closes https://github.com/inveniosoftware/invenio-app-rdm/issues/1770

- Truncate community listing cards name to 30 characters, down from 50.
- Enclosed `access-status` label and icon with a new class to enforce the `min-with`. See comments for more on this. 