### PR TITLE
Bulk indexing for members/invitations `rebuild_index`

### DIFF
--- a/invenio_communities/members/services/config.py
+++ b/invenio_communities/members/services/config.py
@@ -23,6 +23,7 @@ from invenio_records_resources.services.records.queryparser import (
 from ...communities.records.api import Community
 from ...permissions import CommunityPermissionPolicy
 from ..records import Member
+from ..records.api import ArchivedInvitation
 from . import facets
 from .components import CommunityMemberCachingComponent
 from .schemas import MemberEntitySchema
@@ -158,6 +159,10 @@ class MemberServiceConfig(RecordServiceConfig):
     schema = MemberEntitySchema
     indexer_queue_name = "members"
     relations = {"users": ["user"]}
+
+    archive_cls = ArchivedInvitation
+    archive_indexer_cls = RecordServiceConfig.indexer_cls
+    archive_indexer_queue_name = "archived-invitations"
 
     permission_policy_cls = CommunityPermissionPolicy
 

--- a/invenio_communities/views/api.py
+++ b/invenio_communities/views/api.py
@@ -24,10 +24,16 @@ def init(state):
     ext = app.extensions["invenio-communities"]
 
     # services
-    rr_ext.registry.register(ext.service)
+    rr_ext.registry.register(ext.service, service_id="communities")
+    rr_ext.registry.register(ext.service.members, service_id="members")
+
     # indexers
     idx_ext.registry.register(ext.service.indexer, indexer_id="communities")
     idx_ext.registry.register(ext.service.members.indexer, indexer_id="members")
+    idx_ext.registry.register(
+        ext.service.members.archive_indexer, indexer_id="archived-invitations"
+    )
+
     # change notification handlers
     rr_ext.notification_registry.register("users", ext.service.on_relation_update)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,6 +51,14 @@ def app_config(app_config):
         TextCF(name="mycommunityfield", use_as_filter=True),
     ]
 
+    # Define files storage class list
+    app_config["FILES_REST_STORAGE_CLASS_LIST"] = {
+        "L": "Local",
+        "F": "Fetch",
+        "R": "Remote",
+    }
+    app_config["FILES_REST_DEFAULT_STORAGE_CLASS"] = "L"
+
     return app_config
 
 

--- a/tests/members/conftest.py
+++ b/tests/members/conftest.py
@@ -51,6 +51,8 @@ def clean_index(member_service, requests_service, db):
     )
     member_service.rebuild_index(system_identity)
     requests_service.rebuild_index(system_identity)
+    member_service.indexer.process_bulk_queue()
+    requests_service.indexer.process_bulk_queue()
     Member.index.refresh()
     Request.index.refresh()
     ArchivedInvitation.index.refresh()


### PR DESCRIPTION
Make the `service.rebuild_index` method use bulk indexing rather than indexing each item individually.
Related to https://github.com/inveniosoftware/invenio-records-resources/pull/419.