### PR TITLE
community details: add about and curation policy tab

### DIFF
--- a/invenio_communities/assets/semantic-ui/js/invenio_communities/settings/curation-policy/CurationPolicyForm.js
+++ b/invenio_communities/assets/semantic-ui/js/invenio_communities/settings/curation-policy/CurationPolicyForm.js
@@ -1,0 +1,126 @@
+/*
+ * This file is part of Invenio.
+ * Copyright (C) 2023 CERN.
+ *
+ * Invenio is free software; you can redistribute it and/or modify it
+ * under the terms of the MIT License; see LICENSE file for more details.
+ */
+
+import { i18next } from "@translations/invenio_communities/i18next";
+import { Formik } from "formik";
+import _defaultsDeep from "lodash/defaultsDeep";
+import React, { Component } from "react";
+import { FieldLabel, RichInputField, CKEditorConfig } from "react-invenio-forms";
+import { Button, Form, Grid, Icon, Message } from "semantic-ui-react";
+import { CommunityApi } from "../../api";
+import { communityErrorSerializer } from "../../api/serializers";
+import PropTypes from "prop-types";
+import * as Yup from "yup";
+
+const COMMUNITY_VALIDATION_SCHEMA = Yup.object({
+  metadata: Yup.object({
+    curation_policy: Yup.string().max(2000, "Maximum number of characters is 2000"),
+  }),
+});
+
+export class CurationPolicyForm extends Component {
+  state = {
+    error: "",
+  };
+  getInitialValues = () => {
+    const { community } = this.props;
+    let initialValues = _defaultsDeep(community, {
+      metadata: {
+        curation_policy: "",
+      },
+    });
+
+    return initialValues;
+  };
+
+  setGlobalError = (errorMsg) => {
+    this.setState({ error: errorMsg });
+  };
+
+  onSubmit = async (values, { setSubmitting, setFieldError }) => {
+    const { community } = this.props;
+    setSubmitting(true);
+
+    try {
+      const client = new CommunityApi();
+      await client.update(community.id, values);
+      window.location.reload();
+    } catch (error) {
+      if (error === "UNMOUNTED") return;
+
+      const { message, errors } = communityErrorSerializer(error);
+
+      if (message) {
+        this.setGlobalError(message);
+      }
+
+      if (errors) {
+        errors.forEach(({ field, messages }) => setFieldError(field, messages[0]));
+      }
+    }
+
+    setSubmitting(false);
+  };
+  render() {
+    const { error } = this.state;
+    const { community } = this.props;
+    return (
+      <Formik
+        initialValues={this.getInitialValues(community)}
+        validationSchema={COMMUNITY_VALIDATION_SCHEMA}
+        onSubmit={this.onSubmit}
+      >
+        {({ isSubmitting, isValid, handleSubmit }) => (
+          <Form onSubmit={handleSubmit}>
+            <Message hidden={error === ""} negative className="flashed">
+              <Grid container>
+                <Grid.Column width={15} textAlign="left">
+                  <strong>{error}</strong>
+                </Grid.Column>
+              </Grid>
+            </Message>
+            <Grid>
+              <Grid.Row className="pt-10 pb-0">
+                <Grid.Column mobile={16} tablet={16} computer={12} className="rel-pb-2">
+                  <RichInputField
+                    fieldPath="metadata.curation_policy"
+                    label={
+                      <FieldLabel
+                        htmlFor="metadata.curation_policy"
+                        icon="pencil"
+                        label={i18next.t("Curation policy")}
+                      />
+                    }
+                    editorConfig={CKEditorConfig}
+                    fluid
+                  />
+                  <Button
+                    primary
+                    icon
+                    labelPosition="left"
+                    loading={isSubmitting}
+                    disabled={!isValid || isSubmitting}
+                    toggle
+                    type="submit"
+                  >
+                    <Icon name="save" />
+                    {i18next.t("Save")}
+                  </Button>
+                </Grid.Column>
+              </Grid.Row>
+            </Grid>
+          </Form>
+        )}
+      </Formik>
+    );
+  }
+}
+
+CurationPolicyForm.propTypes = {
+  community: PropTypes.object.isRequired,
+};

--- a/invenio_communities/assets/semantic-ui/js/invenio_communities/settings/curation-policy/index.js
+++ b/invenio_communities/assets/semantic-ui/js/invenio_communities/settings/curation-policy/index.js
@@ -1,0 +1,8 @@
+import React from "react";
+import ReactDOM from "react-dom";
+import { CurationPolicyForm } from "./CurationPolicyForm";
+
+const domContainer = document.getElementById("app");
+const community = JSON.parse(domContainer.dataset.community);
+
+ReactDOM.render(<CurationPolicyForm community={community} />, domContainer);

--- a/invenio_communities/assets/semantic-ui/js/invenio_communities/settings/profile/index.js
+++ b/invenio_communities/assets/semantic-ui/js/invenio_communities/settings/profile/index.js
@@ -33,6 +33,8 @@ import {
   RemoteSelectField,
   SelectField,
   TextField,
+  RichInputField,
+  CKEditorConfig,
 } from "react-invenio-forms";
 import {
   Button,
@@ -63,12 +65,7 @@ const COMMUNITY_VALIDATION_SCHEMA = Yup.object({
     type: Yup.object().shape({
       id: Yup.string(),
     }),
-    // TODO: Re-enable once properly integrated to be displayed
-    // page: Yup.string().max(2000, "Maximum number of characters is 2000"),
-    // curation_policy: Yup.string().max(
-    //   2000,
-    //   "Maximum number of characters is 2000"
-    // ),
+    page: Yup.string().max(2000, "Maximum number of characters is 2000"),
   }),
 });
 
@@ -281,9 +278,8 @@ class CommunityProfileForm extends Component {
       metadata: {
         description: "",
         title: "",
-        // TODO: Re-enable once properly integrated to be displayed
-        // curation_policy: "",
-        // page: "",
+        curation_policy: "",
+        page: "",
         type: {},
         website: "",
         organizations: [],
@@ -518,6 +514,10 @@ class CommunityProfileForm extends Component {
                 </Grid.Column>
               </Grid>
             </Message>
+
+            <Header as="h2" size="medium" className="mt-0">
+              {i18next.t("Header content")}
+            </Header>
             <Grid>
               <Grid.Row className="pt-10 pb-0">
                 <Grid.Column mobile={16} tablet={9} computer={9} className="rel-pb-2">
@@ -561,16 +561,7 @@ class CommunityProfileForm extends Component {
                     }
                     fluid
                   />
-                  <TextField
-                    fieldPath="metadata.description"
-                    label={
-                      <FieldLabel
-                        htmlFor="metadata.description"
-                        icon="pencil"
-                        label={i18next.t("Description")}
-                      />
-                    }
-                  />
+
                   <RemoteSelectField
                     fieldPath="metadata.organizations"
                     suggestionAPIUrl="/api/affiliations"
@@ -605,6 +596,24 @@ class CommunityProfileForm extends Component {
                     allowAdditions
                     search={(filteredOptions, searchQuery) => filteredOptions}
                   />
+
+                  <Header as="h2" size="medium">
+                    {i18next.t("About page")}
+                  </Header>
+
+                  <RichInputField
+                    fieldPath="metadata.description"
+                    label={
+                      <FieldLabel
+                        htmlFor="metadata.description"
+                        icon="pencil"
+                        label={i18next.t("Description")}
+                      />
+                    }
+                    editorConfig={CKEditorConfig}
+                    fluid
+                  />
+
                   <FundingField
                     fieldPath="metadata.funding"
                     searchConfig={{
@@ -681,6 +690,7 @@ class CommunityProfileForm extends Component {
                       };
                     }}
                   />
+
                   {!_isEmpty(customFields.ui) && (
                     <CustomFields
                       config={customFields.ui}
@@ -691,32 +701,6 @@ class CommunityProfileForm extends Component {
                     />
                   )}
 
-                  {/* TODO: Re-enable once properly integrated to be displayed */}
-                  {/* <RichInputField
-                    label="Curation policy"
-                    fieldPath="metadata.curation_policy"
-                    label={
-                      <FieldLabel
-                        htmlFor="metadata.curation_policy"
-                        icon={"pencil"}
-                        label="Curation policy"
-                      />
-                    }
-                    editorConfig={CKEditorConfig}
-                    fluid
-                  />
-                  <RichInputField
-                    fieldPath="metadata.page"
-                    label={
-                      <FieldLabel
-                        htmlFor="metadata.page"
-                        icon={"pencil"}
-                        label="Page description"
-                      />
-                    }
-                    editorConfig={CKEditorConfig}
-                    fluid
-                  /> */}
                   <Button
                     disabled={!isValid || isSubmitting}
                     loading={isSubmitting}

--- a/invenio_communities/config.py
+++ b/invenio_communities/config.py
@@ -22,8 +22,11 @@ COMMUNITIES_ROUTES = {
     "settings": "/communities/<pid_value>/settings",
     "requests": "/communities/<pid_value>/requests",
     "settings_privileges": "/communities/<pid_value>/settings/privileges",
+    "settings_curation_policy": "/communities/<pid_value>/settings/curation-policy",
     "members": "/communities/<pid_value>/members",
     "invitations": "/communities/<pid_value>/invitations",
+    "about": "/communities/<pid_value>/about",
+    "curation_policy": "/communities/<pid_value>/curation-policy",
 }
 
 """Communities ui endpoints."""

--- a/invenio_communities/templates/semantic-ui/invenio_communities/details/about/index.html
+++ b/invenio_communities/templates/semantic-ui/invenio_communities/details/about/index.html
@@ -1,0 +1,62 @@
+{# -*- coding: utf-8 -*-
+
+  This file is part of Invenio.
+  Copyright (C) 2023 CERN.
+
+  Invenio is free software; you can redistribute it and/or modify it
+  under the terms of the MIT License; see LICENSE file for more details.
+#}
+
+{% extends "invenio_communities/details/base.html" %}
+{% set active_community_header_menu_item= 'about' %}
+
+{%- block page_body %}
+  {{ super() }}
+  <div class="ui text container rel-mt-2">
+    <h2 class="ui header rel-mt-2">{{ _("About this community") }}</h2>
+    <p class="text-muted">{{ _("Created") }} {{ community.created|invenio_format_datetime }}</p>
+    <p>{{ community.metadata.description | safe }}</p>
+
+    {% if community.ui.funding|length %}
+      <h3 class="ui header">{{ _("Awards") }}</h3>
+      <dl class="ui list">
+
+        {% for funding in community.ui.funding %}
+          <div class="item rel-mb-1">
+            {% if funding.award %}
+              <dd class="header">
+                {{ funding.award.title_l10n }}
+                <label class="ui basic small label">
+                  {{funding.award.number}}
+                </label>
+
+                {% if funding.award.identifiers|length and funding.award.identifiers[0].scheme == "url" %}
+                  <a
+                    class="ui transparent icon button"
+                    href="{{ funding.award.identifiers[0].identifier }}"
+                    aria-label="{{ _('Visit external website') }}"
+                    title="{{ _('Opens in new tab') }}"
+                  >
+                    <i class="external primary icon" aria-hidden="true"></i>
+                  </a>
+                {% endif %}
+              </dd>
+            {% endif %}
+
+            {% if funding.funder %}
+              <dt class="text-muted">
+                {{ funding.funder.name }}
+              </dt>
+            {% endif %}
+          </div>
+        {% endfor %}
+
+      </dl>
+    {% endif %}
+  </div>
+
+  {% include "invenio_communities/details/upload-instructions.html" %}
+
+
+
+{%- endblock page_body -%}

--- a/invenio_communities/templates/semantic-ui/invenio_communities/details/curation_policy/index.html
+++ b/invenio_communities/templates/semantic-ui/invenio_communities/details/curation_policy/index.html
@@ -1,0 +1,24 @@
+{# -*- coding: utf-8 -*-
+
+  This file is part of Invenio.
+  Copyright (C) 2023 CERN.
+
+  Invenio is free software; you can redistribute it and/or modify it
+  under the terms of the MIT License; see LICENSE file for more details.
+#}
+
+{% extends "invenio_communities/details/base.html" %}
+{% set active_community_header_menu_item= 'curation_policy' %}
+
+
+{%- block page_body %}
+  {{ super() }}
+  <div class="ui text container rel-mt-2">
+    <h2 class="ui header rel-mt-2">{{ _("Curation policy") }}</h2>
+    {{ community.metadata.curation_policy | safe }}
+  </div>
+
+  {% include "invenio_communities/details/upload-instructions.html" %}
+
+
+{%- endblock page_body -%}

--- a/invenio_communities/templates/semantic-ui/invenio_communities/details/header.html
+++ b/invenio_communities/templates/semantic-ui/invenio_communities/details/header.html
@@ -16,25 +16,24 @@
     <div class="row pb-0">
       <div
         class="sixteen wide mobile sixteen wide tablet thirteen wide computer column">
-        <div class="community-header ui grid">
-          <div class="two wide column">
-            <div class="ui rounded image community-image mt-5 rel-mr-2">
-              <img
-                src="{{ community.links.logo }}"
-                alt=""
-                class="has-placeholder"
-              />
-            </div>
+        <div class="community-header flex align-items-center">
+          <div class="ui rounded image community-image mt-5 rel-mr-2">
+            <img
+              src="{{ community.links.logo }}"
+              alt=""
+              class="has-placeholder"
+            />
           </div>
-          <div class="fourteen wide column">
+
+          <div>
             {% if community.access.visibility == 'restricted' %}
               <div class="rel-mb-2 mobile only">
                 {{ access_status_label() }}
               </div>
             {% endif %}
 
-            <div class="flex align-items-center rel-mb-1">
-              <h2 class="ui mb-0">{{ community.metadata.title }}</h2>
+            <div class="flex align-items-center mb-5">
+              <h1 class="ui large header mb-0">{{ community.metadata.title }}</h1>
               {% if community.access.visibility == 'restricted' %}
                 <div class="rel-ml-1 computer only tablet only">
                   {{ access_status_label() }}
@@ -69,27 +68,6 @@
                 </div>
               {% endif %}
             </div>
-
-            {% if community.metadata.description %}
-              <div class="ui accordion mt-5">
-                <div id="description-accordion"
-                     role="button"
-                     aria-controls="community-description"
-                     aria-expanded="false"
-                     tabindex="0"
-                     class="title trigger"
-                >
-                  {{ _("About this community") }}
-                  <i class="icon right chevron pl-5"></i>
-                </div>
-                <div id="community-description"
-                     aria-labelledby="description-accordion"
-                     class="content rel-mb-2"
-                >
-                  {{ community.metadata.description }}
-                </div>
-              </div>
-            {% endif %}
           </div>
         </div>
       </div>

--- a/invenio_communities/templates/semantic-ui/invenio_communities/details/settings/base.html
+++ b/invenio_communities/templates/semantic-ui/invenio_communities/details/settings/base.html
@@ -17,6 +17,7 @@
     {%- set menu_items = {
       'profile': (_('Profile'), url_for('invenio_communities.communities_settings', pid_value=community.slug), ),
       'privileges': (_('Privileges'), url_for('invenio_communities.communities_settings_privileges', pid_value=community.slug)),
+      'curation_policy': (_('Curation policy'), url_for('invenio_communities.communities_settings_curation_policy', pid_value=community.slug)),
     } %}
     <div class="sixteen wide mobile sixteen wide tablet three wide computer column">
       <div class="ui vertical computer horizontal tablet horizontal mobile menu">

--- a/invenio_communities/templates/semantic-ui/invenio_communities/details/settings/curation_policy.html
+++ b/invenio_communities/templates/semantic-ui/invenio_communities/details/settings/curation_policy.html
@@ -1,0 +1,27 @@
+{# -*- coding: utf-8 -*-
+
+  This file is part of Invenio.
+  Copyright (C) 2023 CERN.
+
+  Invenio is free software; you can redistribute it and/or modify it
+  under the terms of the MIT License; see LICENSE file for more details.
+#}
+
+{% extends "invenio_communities/details/settings/base.html" %}
+
+{%- block javascript %}
+{{ super() }}
+{{ webpack['invenio-communities-curation-policy.js'] }}
+{%- endblock javascript %}
+
+{% set active_settings_menu_item = 'curation_policy' %}
+{% set active_community_header_menu_item = 'settings' %}
+
+{%- block settings_body %}
+<div class="sixteen wide mobile sixteen wide tablet thirteen wide computer column">
+  <div
+    id="app"
+    data-community='{{ community | tojson }}'>
+  </div>
+</div>
+{%- endblock settings_body %}

--- a/invenio_communities/templates/semantic-ui/invenio_communities/details/upload-instructions.html
+++ b/invenio_communities/templates/semantic-ui/invenio_communities/details/upload-instructions.html
@@ -1,0 +1,13 @@
+<div class="ui container rel-mt-2">
+    <div class="ui divider" aria-hidden="true"></div>
+    <div class="ui text container rel-mt-2">
+
+    <h2 class="ui small header">Want your upload to appear in this community?</h2>
+      <ul>
+        <!-- TODO: This text content needs to be updated (Copied from Zenodo) -->
+        <li>Click the "New upload" button above to upload a record directly to this community.</li>
+        <li>The community curator will then be notified to either accept or reject your upload (see the community <a href="{{ url_for('invenio_communities.communities_curation_policy', pid_value=community.slug) }}">curation policy</a>).</li>
+        <li>If your upload is rejected by the curator, it will still be available, just not in this community.</li>
+      </ul>
+    </div>
+  </div>

--- a/invenio_communities/views/communities.py
+++ b/invenio_communities/views/communities.py
@@ -217,6 +217,20 @@ def communities_settings_privileges(pid_value, community, community_ui):
 
 
 @pass_community(serialize=True)
+def communities_settings_curation_policy(pid_value, community, community_ui):
+    """Community settings/curation-policy page."""
+    permissions = community.has_permissions_to(["update", "read", "search_requests"])
+    if not permissions["can_update"]:
+        raise PermissionDeniedError()
+
+    return render_template(
+        "invenio_communities/details/settings/curation_policy.html",
+        community=community_ui,
+        permissions=permissions,
+    )
+
+
+@pass_community(serialize=True)
 def members(pid_value, community, community_ui):
     """Community members page."""
     permissions = community.has_permissions_to(
@@ -260,5 +274,44 @@ def invitations(pid_value, community, community_ui):
         "invenio_communities/details/members/invitations.html",
         community=community_ui,
         roles_can_invite=_get_roles_can_invite(community.id),
+        permissions=permissions,
+    )
+
+
+@pass_community(serialize=True)
+def communities_about(pid_value, community, community_ui):
+    """Community about page."""
+    permissions = community.has_permissions_to(
+        [
+            "update",
+            "read",
+            "search_requests",
+        ]
+    )
+    if not permissions["can_read"]:
+        raise PermissionDeniedError()
+    return render_template(
+        "invenio_communities/details/about/index.html",
+        community=community_ui,
+        permissions=permissions,
+        custom_fields=load_custom_fields(dump_only_required=False),
+    )
+
+
+@pass_community(serialize=True)
+def communities_curation_policy(pid_value, community, community_ui):
+    """Community curation policy page."""
+    permissions = community.has_permissions_to(
+        [
+            "update",
+            "read",
+            "search_requests",
+        ]
+    )
+    if not permissions["can_read"]:
+        raise PermissionDeniedError()
+    return render_template(
+        "invenio_communities/details/curation_policy/index.html",
+        community=community_ui,
         permissions=permissions,
     )

--- a/invenio_communities/webpack.py
+++ b/invenio_communities/webpack.py
@@ -29,6 +29,7 @@ communities = WebpackThemeBundle(
                 "invenio-communities-new": "./js/invenio_communities/community/new.js",
                 "invenio-communities-privileges": "./js/invenio_communities/settings/privileges.js",
                 "invenio-communities-profile": "./js/invenio_communities/settings/profile/index.js",
+                "invenio-communities-curation-policy": "./js/invenio_communities/settings/curation-policy/index.js",
                 "invenio-communities-requests": "./js/invenio_communities/requests/index.js",
                 "invenio-communities-frontpage": "./js/invenio_communities/community/frontpage.js",
                 "invenio-communities-details-search": "./js/invenio_communities/details_search/index.js",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -335,6 +335,7 @@ def fake_communities(
     data = deepcopy(minimal_community)
     """Multiple community created and posted to test search functionality."""
     N = 4
+
     for type_, ind in itertools.product(community_types, list(range(N))):
         data["slug"] = f'comm_{type_["id"]}_{ind}'
         data["metadata"]["type"] = {"id": type_["id"]}


### PR DESCRIPTION
Closes https://github.com/inveniosoftware/invenio-communities/issues/867

Needs https://github.com/inveniosoftware/invenio-app-rdm/pull/2057

## Changes
- Moved the about section from the header to new tab
- Added  new tab for curation policy
- Added new tab on the settings page for curation policy
- Added TODO comment for updating the upload-instructions text


## Screenshots

### Settings page
-  I renamed the "Description" field in the settings page to "Summary", as we have the "Page description" below. This will show up above the "page description" on the about page (see above divider in the about page - next screenshot). Let me know if this should be renamed, or solved differently?
![Screenshot 2023-02-06 at 14 46 28](https://user-images.githubusercontent.com/21052053/216990465-4c5aeb78-5acd-443f-bfbe-3bb8f88dc180.png)

### About page
![Screenshot 2023-02-03 at 17 18 01](https://user-images.githubusercontent.com/21052053/216987094-cd2c6d6a-5c9b-4998-9337-c81773becdb6.png)

### Curation policy page
![Screenshot 2023-02-03 at 17 15 11](https://user-images.githubusercontent.com/21052053/216987245-e64810e9-aa38-4570-927c-23f0d5cb85e2.png)

### Curation policy settings page
![Screenshot 2023-02-03 at 16 43 37](https://user-images.githubusercontent.com/21052053/216988770-139aaba0-9257-45ac-a448-c2d46b9e2495.png)
