### PR TITLE
migrate to flask babel

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,12 @@
 Changes
 =======
 
+Version 5.2.0 (released 2023-03-03)
+-----------------------------------
+
+- remove deprecated flask_babelex dependency and imports
+- upgrade invenio dependencies
+
 Version 5.1.0 (released 2023-02-24)
 -----------------------------------
 

--- a/invenio_communities/__init__.py
+++ b/invenio_communities/__init__.py
@@ -11,6 +11,6 @@
 from .ext import InvenioCommunities
 from .proxies import current_communities
 
-__version__ = "5.1.0"
+__version__ = "5.2.0"
 
 __all__ = ("InvenioCommunities", "current_communities")

--- a/invenio_communities/communities/schema.py
+++ b/invenio_communities/communities/schema.py
@@ -2,6 +2,7 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2016-2021 CERN.
+# Copyright (C) 2023 Graz University of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -11,7 +12,7 @@ import re
 from functools import partial
 from uuid import UUID
 
-from flask_babelex import lazy_gettext as _
+from invenio_i18n import lazy_gettext as _
 from invenio_records_resources.services.custom_fields import CustomFieldsSchema
 from invenio_records_resources.services.records.schema import BaseRecordSchema
 from invenio_vocabularies.contrib.affiliations.schema import AffiliationRelationSchema

--- a/invenio_communities/communities/services/components.py
+++ b/invenio_communities/communities/services/components.py
@@ -3,16 +3,16 @@
 # This file is part of Invenio.
 # Copyright (C) 2016-2022 CERN.
 # Copyright (C) 2022 Northwestern University.
-# Copyright (C) 2022 Graz University of Technology.
+# Copyright (C) 2022-2023 Graz University of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
 """Components."""
 
-from flask_babelex import lazy_gettext as _
 from invenio_access.permissions import system_identity, system_process
 from invenio_db import db
+from invenio_i18n import lazy_gettext as _
 from invenio_oaiserver.models import OAISet
 from invenio_pidstore.errors import PIDDeletedError, PIDDoesNotExistError
 from invenio_records_resources.services.records.components import ServiceComponent

--- a/invenio_communities/communities/services/config.py
+++ b/invenio_communities/communities/services/config.py
@@ -3,13 +3,14 @@
 # This file is part of Invenio.
 # Copyright (C) 2016-2022 CERN.
 # Copyright (C) 2022 Northwestern University.
+# Copyright (C) 2023 Graz University of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
 """Invenio Communities Service API config."""
 
-from flask_babelex import lazy_gettext as _
+from invenio_i18n import lazy_gettext as _
 from invenio_records_resources.services import FileServiceConfig
 from invenio_records_resources.services.base.config import (
     ConfiguratorMixin,

--- a/invenio_communities/communities/services/facets.py
+++ b/invenio_communities/communities/services/facets.py
@@ -1,13 +1,14 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2022 CERN.
+# Copyright (C) 2023 Graz University of Technology.
 #
 # Invenio-RDM-Records is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more details.
 
 """Facet definitions."""
 
-from flask_babelex import gettext as _
+from invenio_i18n import gettext as _
 from invenio_records_resources.services.records.facets import TermsFacet
 
 type = TermsFacet(

--- a/invenio_communities/config.py
+++ b/invenio_communities/config.py
@@ -2,6 +2,7 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2016-2022 CERN.
+# Copyright (C) 2023 Graz University of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -10,7 +11,7 @@
 
 from datetime import timedelta
 
-from flask_babelex import lazy_gettext as _
+from invenio_i18n import lazy_gettext as _
 
 from invenio_communities.communities.services import facets
 

--- a/invenio_communities/errors.py
+++ b/invenio_communities/errors.py
@@ -9,7 +9,7 @@
 
 from math import ceil
 
-from flask_babelex import gettext as _
+from invenio_i18n import gettext as _
 
 
 class CommunityError(Exception):

--- a/invenio_communities/members/services/config.py
+++ b/invenio_communities/members/services/config.py
@@ -2,13 +2,14 @@
 #
 # Copyright (C) 2022 Northwestern University.
 # Copyright (C) 2022 CERN.
+# Copyright (C) 2023 Graz University of Technology.
 #
 # Invenio-Communities is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more details.
 
 """Members Service Config."""
 
-from flask_babelex import lazy_gettext as _
+from invenio_i18n import lazy_gettext as _
 from invenio_records_resources.services import (
     RecordServiceConfig,
     SearchOptions,

--- a/invenio_communities/members/services/facets.py
+++ b/invenio_communities/members/services/facets.py
@@ -1,13 +1,14 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2022 CERN.
+# Copyright (C) 2023 Graz University of Technology.
 #
 # Invenio-Communities is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more details.
 
 """Facets for the members search."""
 
-from flask_babelex import gettext as _
+from invenio_i18n import gettext as _
 from invenio_records_resources.services.records.facets import TermsFacet
 
 from ...proxies import current_roles

--- a/invenio_communities/members/services/fields.py
+++ b/invenio_communities/members/services/fields.py
@@ -1,13 +1,14 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2022 CERN.
+# Copyright (C) 2023 Graz University of Technology.
 #
 # Invenio-Communities is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more details.
 
 """Marshmallow fields."""
 
-from flask_babelex import lazy_gettext as _
+from invenio_i18n import lazy_gettext as _
 from marshmallow import fields
 
 from ...proxies import current_roles

--- a/invenio_communities/members/services/request.py
+++ b/invenio_communities/members/services/request.py
@@ -2,14 +2,15 @@
 #
 # Copyright (C) 2022 Northwestern University.
 # Copyright (C) 2022 CERN.
+# Copyright (C) 2023 Graz University of Technology.
 #
 # Invenio-Communities is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more details.
 
 """Invitation request type."""
 
-from flask_babelex import lazy_gettext as _
 from invenio_access.permissions import system_identity
+from invenio_i18n import lazy_gettext as _
 from invenio_requests.customizations import RequestType, actions
 
 from ...proxies import current_communities

--- a/invenio_communities/members/services/schemas.py
+++ b/invenio_communities/members/services/schemas.py
@@ -2,6 +2,7 @@
 #
 # Copyright (C) 2022 Northwestern University.
 # Copyright (C) 2022 CERN.
+# Copyright (C) 2023 Graz University of Technology.
 #
 # Invenio-Communities is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more details.
@@ -11,7 +12,7 @@
 from datetime import timezone
 from types import SimpleNamespace
 
-from flask_babelex import lazy_gettext as _
+from invenio_i18n import lazy_gettext as _
 from invenio_users_resources.proxies import (
     current_groups_service,
     current_users_service,

--- a/invenio_communities/members/services/service.py
+++ b/invenio_communities/members/services/service.py
@@ -2,7 +2,7 @@
 #
 # Copyright (C) 2022 Northwestern University.
 # Copyright (C) 2022 CERN.
-# Copyright (C) 2022 Graz University of Technology.
+# Copyright (C) 2022-2023 Graz University of Technology.
 #
 # Invenio-Communities is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more details.
@@ -12,9 +12,9 @@
 from datetime import datetime, timezone
 
 from flask import current_app
-from flask_babelex import gettext as _
 from invenio_access.permissions import system_identity
 from invenio_accounts.models import Role
+from invenio_i18n import gettext as _
 from invenio_records_resources.services import LinksTemplate
 from invenio_records_resources.services.records import (
     RecordService,

--- a/invenio_communities/views/communities.py
+++ b/invenio_communities/views/communities.py
@@ -2,6 +2,7 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2016-2021 CERN.
+# Copyright (C) 2023 Graz University of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -11,8 +12,8 @@
 from copy import deepcopy
 
 from flask import current_app, g, render_template
-from flask_babelex import lazy_gettext as _
 from flask_login import login_required
+from invenio_i18n import lazy_gettext as _
 from invenio_records_resources.services.errors import PermissionDeniedError
 from invenio_vocabularies.proxies import current_service as vocabulary_service
 

--- a/invenio_communities/views/ui.py
+++ b/invenio_communities/views/ui.py
@@ -2,6 +2,7 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2016-2021 CERN.
+# Copyright (C) 2023 Graz University of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -12,9 +13,9 @@ from datetime import datetime
 
 from babel.dates import format_datetime
 from flask import Blueprint, current_app, render_template
-from flask_babelex import lazy_gettext as _
 from flask_login import current_user
 from flask_menu import current_menu
+from invenio_i18n import lazy_gettext as _
 from invenio_pidstore.errors import PIDDeletedError, PIDDoesNotExistError
 from invenio_records_resources.services.errors import PermissionDeniedError
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,11 +27,11 @@ packages = find:
 python_requires = >=3.7
 zip_safe = False
 install_requires =
-    invenio-oaiserver>=2.0.0,<3.0.0
-    invenio-requests>=1.0.0,<2.0.0
-    invenio-search-ui>=2.3.0,<3.0.0
-    invenio-vocabularies>=1.0.0,<2.0.0
-    invenio-administration>=1.0.0,<2.0.0
+    invenio-oaiserver>=2.2.0,<3.0.0
+    invenio-requests>=1.1.0,<2.0.0
+    invenio-search-ui>=2.4.0,<3.0.0
+    invenio-vocabularies>=1.1.0,<2.0.0
+    invenio-administration>=1.1.0,<2.0.0
 
 [options.extras_require]
 tests =


### PR DESCRIPTION
- migrate: flask_babelex replaced by invenio_i18n
- fix: black issues due to higher version

- NOTE invenio-i18n has to be released first