### PR TITLE
components: forbid visibility changes if it contains incoherent records

### DIFF
--- a/invenio_communities/communities/services/components.py
+++ b/invenio_communities/communities/services/components.py
@@ -79,6 +79,18 @@ class CommunityAccessComponent(ServiceComponent):
     def update(self, identity, data=None, record=None, **kwargs):
         """Update handler."""
         self._populate_access_and_validate(identity, data, record, **kwargs)
+        visibility = data["access"]["visibility"]
+        opposite = "public" if visibility == "public" else "restricted"
+        total = self.service.search(q={"access.visibility": opposite})
+        if total > 0:
+            raise ValidationError(
+                field="access.visibility",
+                messages=[
+                    _(
+                        "Cannot change community visibility since it contains {} records"
+                    ).format(visibility)
+                ],
+            )
 
 
 class OwnershipComponent(ServiceComponent):


### PR DESCRIPTION
- closes #818 

Notes:
- The code is not functional, just pseudocode to decide if the solution is accepted.
- I am assuming that we should not allow to:
   - change from public to restricted, if there are public records
   - change from restricted to public, if there are restricted records (this could be ok though 🤔 )