### PR TITLE
about page: display custom fields

### DIFF
--- a/invenio_communities/templates/semantic-ui/invenio_communities/details/about/index.html
+++ b/invenio_communities/templates/semantic-ui/invenio_communities/details/about/index.html
@@ -8,13 +8,13 @@
 #}
 
 {% extends "invenio_communities/details/base.html" %}
+{% from "invenio_communities/details/macros/custom_fields.html" import list_vocabulary_values, list_string_values, show_custom_field %}
 {% set active_community_header_menu_item= 'about' %}
 
 {%- block page_body %}
   {{ super() }}
   <div class="ui text container rel-mt-2 rel-pt-1 rel-mb-2">
     {{ community.metadata.page | safe }}
-
     {% if community.ui.funding|length %}
       <h3 class="ui header">{{ _("Awards") }}</h3>
       <dl class="ui list">
@@ -51,5 +51,25 @@
 
       </dl>
     {% endif %}
+
+
+    {% set custom_fields = community.ui.custom_fields %}
+
+    {% for section_cfg in custom_fields_ui if custom_fields %}
+      {% set section_fields = section_cfg.fields %}
+
+      <h2>{{ section_cfg.section }}</h2>
+
+      {% for field_cfg in section_fields %}
+        {% set field_value = custom_fields.get(field_cfg.field) %}
+
+        {% if field_value and field_cfg.template %}
+          {% include field_cfg.template %}
+        {% elif field_value and not field_cfg.template %}
+          <dt class="ui tiny header">{{ field_cfg.props.label }}</dt>
+          {{ show_custom_field(field_value, field_cfg) }}
+        {% endif %}
+      {% endfor %}
+    {%- endfor %}
   </div>
 {%- endblock page_body -%}

--- a/invenio_communities/templates/semantic-ui/invenio_communities/details/macros/custom_fields.html
+++ b/invenio_communities/templates/semantic-ui/invenio_communities/details/macros/custom_fields.html
@@ -1,0 +1,44 @@
+{# -*- coding: utf-8 -*-
+
+  This file is part of Invenio.
+  Copyright (C) 2023 CERN.
+
+  Invenio is free software; you can redistribute it and/or modify it
+  under the terms of the MIT License; see LICENSE file for more details.
+#}
+
+{% macro list_vocabulary_values(values) %}
+  {% if values.title_l10n is defined %}
+    {{ values.title_l10n }}
+  {% else %}
+    {% for value in values %}
+      {{ value.title_l10n }}{{ ", " if not loop.last }}
+    {% endfor %}
+  {% endif %}
+{% endmacro %}
+
+{% macro list_string_values(values) %}
+  {% for value in values %}
+    {{ value }}{{ ", " if not loop.last }}
+  {% endfor %}
+{% endmacro %}
+
+{% macro show_custom_field(value, config) %}
+  {% if value is string %}
+    <dd>{{ value | safe }}</dd>
+  {% elif value is boolean %}
+    <dd>
+      {% if value %}
+        {{ config.props.trueLabel}}
+      {% else %}
+        {{ config.props.falseLabel }}
+      {% endif %}
+    </dd>
+  {% elif config.is_vocabulary %}
+    <dd>{{ list_vocabulary_values(value) }}</dd>
+  {% elif value is mapping and value|length > 0 and value[0] is string %}
+    <dd>{{ list_string_values(value) }}</dd>
+  {% else %}
+    <dd>{{ value }}</dd>
+  {% endif %}
+{% endmacro %}

--- a/invenio_communities/views/communities.py
+++ b/invenio_communities/views/communities.py
@@ -334,7 +334,7 @@ def communities_about(pid_value, community, community_ui):
         "invenio_communities/details/about/index.html",
         community=community_ui,
         permissions=permissions,
-        custom_fields=load_custom_fields(dump_only_required=False),
+        custom_fields_ui=load_custom_fields(dump_only_required=False)["ui"],
     )
 
 


### PR DESCRIPTION
Closes https://github.com/inveniosoftware/invenio-communities/issues/892

Adds custom fields to the community "About" page.

## Screenshot
![Screenshot 2023-03-28 at 10 04 20](https://user-images.githubusercontent.com/21052053/228190232-c24d3f57-d52e-4c92-8c31-1e26bbb5ceb6.png)
