### PR TITLE
delete community: display metrics on deletion modal

### DIFF
--- a/invenio_communities/communities/services/config.py
+++ b/invenio_communities/communities/services/config.py
@@ -109,6 +109,7 @@ class CommunityServiceConfig(RecordServiceConfig, ConfiguratorMixin):
         "public_members": CommunityLink("{+api}/communities/{id}/members/public"),
         "invitations": CommunityLink("{+api}/communities/{id}/invitations"),
         "requests": CommunityLink("{+api}/communities/{id}/requests"),
+        "records": CommunityLink("{+api}/communities/{id}/records"),
     }
 
     action_link = CommunityLink(


### PR DESCRIPTION
* closes https://github.com/inveniosoftware/invenio-communities/issues/935

### Description

When a user decides to delete a community the Community Deletion Modal pops up, to make sure the user is aware of the impact of their actions. Some community metrics (member and record counts) are now displayed on the Community Deletion Modal. 

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/best-practices/i18n/) (for relevant code).
- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines (for relevant code).
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines (for relevant code).
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines (for relevant code).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
