### PR TITLE
CommunityItem: Improve consistency of spacing

### DIFF
--- a/invenio_communities/assets/semantic-ui/js/invenio_communities/community/communitiesItems/CommunityCompactItemComputer.js
+++ b/invenio_communities/assets/semantic-ui/js/invenio_communities/community/communitiesItems/CommunityCompactItemComputer.js
@@ -41,13 +41,14 @@ export const CommunityCompactItemComputer = ({
               </a>
             </Item.Header>
 
-            <Item.Description>
-              <div
+            {metadata.description && (
+              <Item.Description
+                as="p"
                 dangerouslySetInnerHTML={{
                   __html: _truncate(metadata.description, { length: 50 }),
                 }}
               />
-            </Item.Description>
+            )}
             <Item.Extra>
               <RestrictedLabel access={access.visibility} />
               <CommunityTypeLabel type={communityType} />

--- a/invenio_communities/assets/semantic-ui/js/invenio_communities/community/communitiesItems/CommunityCompactItemMobile.js
+++ b/invenio_communities/assets/semantic-ui/js/invenio_communities/community/communitiesItems/CommunityCompactItemMobile.js
@@ -26,11 +26,15 @@ export const CommunityCompactItemMobile = ({ result, actions }) => {
           </a>
         </Item.Header>
 
-        <Item.Description
-          dangerouslySetInnerHTML={{
-            __html: _truncate(result.metadata.description, { length: 50 }),
-          }}
-        />
+        {result.metadata.description && (
+          <Item.Description
+            as="p"
+            dangerouslySetInnerHTML={{
+              __html: _truncate(result.metadata.description, { length: 50 }),
+            }}
+          />
+        )}
+
         <Item.Extra>
           <RestrictedLabel access={result.access.visibility} />
           <CommunityTypeLabel type={communityType} />

--- a/invenio_communities/assets/semantic-ui/js/invenio_communities/community/communitiesItems/CommunityItemComputer.js
+++ b/invenio_communities/assets/semantic-ui/js/invenio_communities/community/communitiesItems/CommunityItemComputer.js
@@ -30,23 +30,28 @@ export const CommunityItemComputer = ({ result }) => {
             <Item.Header size="medium" as={Header}>
               <a href={result.links.self_html}>{result.metadata.title}</a>
             </Item.Header>
-            <Item.Meta>
-              <a
-                href={result.metadata.website}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                {result.metadata.website}
-              </a>
-            </Item.Meta>
-            <Item.Description>
-              <div
+
+            {result.metadata.website && (
+              <Item.Meta>
+                <a
+                  href={result.metadata.website}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  {result.metadata.website}
+                </a>
+              </Item.Meta>
+            )}
+
+            {result.metadata.description && (
+              <Item.Description
+                as="p"
                 className="truncate-lines-2"
                 dangerouslySetInnerHTML={{
                   __html: result.metadata.description,
                 }}
               />
-            </Item.Description>
+            )}
 
             <Item.Extra>
               <RestrictedLabel access={result.access.visibility} />

--- a/invenio_communities/assets/semantic-ui/js/invenio_communities/community/communitiesItems/CommunityItemMobile.js
+++ b/invenio_communities/assets/semantic-ui/js/invenio_communities/community/communitiesItems/CommunityItemMobile.js
@@ -26,25 +26,35 @@ export const CommunityItemMobile = ({ result, index }) => {
         <Item.Extra>
           <Image wrapped src={result.links.logo} size="small" />
         </Item.Extra>
-        <Item.Header as="h2" className="rel-mt-1">
+        <Item.Header as="h2" className="rel-mt-1 mb-10">
           <a href={result.links.self_html}>{result.metadata.title}</a>
         </Item.Header>
-        <Item.Meta>
-          <div
-            className="truncate-lines-2"
+
+        {result.metadata.description && (
+          <Item.Description
+            as="p"
+            className="truncate-lines-2 mb-10"
             dangerouslySetInnerHTML={{
               __html: result.metadata.description,
             }}
           />
-        </Item.Meta>
-        <Item>
-          {result.metadata.website && (
-            <a href={result.metadata.website} target="_blank" rel="noopener noreferrer">
-              {result.metadata.website}
-            </a>
-          )}
-        </Item>
-        <Item.Extra>
+        )}
+
+        {result.metadata.website && (
+          <Item.Meta className="mb-10">
+            {result.metadata.website && (
+              <a
+                href={result.metadata.website}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {result.metadata.website}
+              </a>
+            )}
+          </Item.Meta>
+        )}
+
+        <Item.Extra className="mb-10">
           {i18next.t("Created: ")}
           {DateTime.fromISO(result.created).toLocaleString(i18next.language)}
         </Item.Extra>


### PR DESCRIPTION
Closes https://github.com/inveniosoftware/invenio-communities/issues/950

This PR makes the spacing in the CommunityItem more consistent by adding margins and preventing empty elements (with margins) to show up.

## Screenshots

### Desktop
<img width="957" alt="Screenshot 2023-05-05 at 17 29 01" src="https://user-images.githubusercontent.com/21052053/236508094-950371da-ae8e-4f06-b884-b8a69c058237.png">

### Tablet
<img width="735" alt="Screenshot 2023-05-05 at 17 29 08" src="https://user-images.githubusercontent.com/21052053/236508101-68e32c6e-f279-4213-a208-5d1427c5992a.png">

### Mobile
<img width="365" alt="Screenshot 2023-05-05 at 17 36 40" src="https://user-images.githubusercontent.com/21052053/236508107-92a9c2b1-ca4c-412c-8a7a-f6c89e0b7d77.png">