### PR TITLE
search header: align style with My account header

### DIFF
--- a/invenio_communities/templates/semantic-ui/invenio_communities/search.html
+++ b/invenio_communities/templates/semantic-ui/invenio_communities/search.html
@@ -19,7 +19,7 @@
 {%- block page_body %}
 <div class="ui container fluid page-subheader-outer compact ml-0-mobile mr-0-mobile">
   <div class="ui container community-search page-subheader">
-    <h3 class="ui header">{{_("Communities")}}</h3>
+    <h1 class="ui large header">{{_("Communities")}}</h1>
   </div>
 </div>
 <div id="communities-search" class="rel-mt-3" data-invenio-search-config='{{


### PR DESCRIPTION
closes https://github.com/inveniosoftware/invenio-github/issues/115

- Changes header to h1 and aligns size with similar header for My account

<img width="1269" alt="Screenshot 2023-07-19 at 14 49 40" src="https://github.com/inveniosoftware/invenio-communities/assets/21052053/1d7e7187-c782-407d-80f2-864f6509605f">

![Screenshot 2023-07-18 at 16 04 50](https://github.com/inveniosoftware/invenio-communities/assets/21052053/968502f9-9953-41df-8884-62ba8d89dfeb)
