### PR TITLE
templates: access message and mark subject for translation

### DIFF
--- a/invenio_communities/templates/semantic-ui/invenio_notifications/community-invitation.submit.jinja
+++ b/invenio_communities/templates/semantic-ui/invenio_notifications/community-invitation.submit.jinja
@@ -4,7 +4,7 @@
 {% set request_id = invitation_request.id %}
 
 {% set community_title = community.metadata.title %}
-{% set message = notification.context.message | safe if message else '' %}
+{% set message = notification.context.message | safe if notification.context.message else '' %}
 {% set role = notification.context.role %}
 
 {# TODO: use request.links.self_html when issue issue is resolved: https://github.com/inveniosoftware/invenio-rdm-records/issues/1327 #}
@@ -14,12 +14,12 @@
 %}
 
 {%- block subject -%}
-New invitation to join community {{ community_title }} as {{ role }}
+  {{ _("New invitation to join community '{community_title}' as '{role}'.").format(community_title=community_title, role=role) }}
 {%- endblock subject -%}
 
 {%- block html_body -%}
 <p>
-    {{ _("You have been invited to join community '{community_title}' as '{role}'").format(community_title=community_title, role=role) }}.
+    {{ _("You have been invited to join community '{community_title}' as '{role}'.").format(community_title=community_title, role=role) }}
 </p>
 
 {%- if message %}
@@ -33,7 +33,7 @@ New invitation to join community {{ community_title }} as {{ role }}
 {%- endblock html_body %}
 
 {%- block plain_body -%}
-{{ _("You have been invited to join community '{community_title}' as '{role}'").format(community_title=community_title, role=role) }}.
+{{ _("You have been invited to join community '{community_title}' as '{role}'.").format(community_title=community_title, role=role) }}
 
 {%- if message %}
     {{ _("Invitation message:") }}
@@ -45,7 +45,7 @@ New invitation to join community {{ community_title }} as {{ role }}
 
 {# Markdown for Slack/Mattermost/chat #}
 {%- block md_body -%}
-{{ _("You have been invited to join community *{community_title}* as *{role}*").format(community_title=community_title, role=role) }}.
+{{ _("You have been invited to join community *{community_title}* as *{role}*.").format(community_title=community_title, role=role) }}
 
 {%- if message %}
     {{ _("Invitation message:") }}


### PR DESCRIPTION
tests: adapt invitation notification testcase

:heart: Thank you for your contribution!

### Description

Access invitation message via notification context in jinja template.
Adapt test to test for the (non-)existence of the message.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/best-practices/i18n/) (for relevant code).
- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines (for relevant code).
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines (for relevant code).
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines (for relevant code).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).

**Third-party code**

If you've added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
