### PR TITLE
details header: remove hardcoded header, remove empty tabs

### DIFF
--- a/invenio_communities/templates/semantic-ui/invenio_communities/details/curation_policy/index.html
+++ b/invenio_communities/templates/semantic-ui/invenio_communities/details/curation_policy/index.html
@@ -13,8 +13,7 @@
 
 {%- block page_body %}
   {{ super() }}
-  <div class="ui text container rel-m-2">
-    <h2 class="ui header rel-mt-2">{{ _("Curation policy") }}</h2>
+  <div class="ui text container rel-m-2 rel-pt-1">
     {{ community.metadata.curation_policy | safe }}
   </div>
 {%- endblock page_body -%}

--- a/invenio_communities/templates/semantic-ui/invenio_communities/details/header.html
+++ b/invenio_communities/templates/semantic-ui/invenio_communities/details/header.html
@@ -139,7 +139,7 @@
     <div class="ui divider mobile only"></div>
     <div
       class="ui container secondary pointing stackable menu page-subheader pl-0 pr-0">
-      {% for item in current_menu.submenu('communities').children if item.permissions == True or permissions[item.permissions] %}
+      {% for item in current_menu.submenu('communities').children if (item.permissions == True or permissions[item.permissions]) and item.visible %}
           <a
             class="item {{ 'active' if active_community_header_menu_item == item.name }} {{ 'disabled' if not item.url }}"
             href="{{ item.url }}"

--- a/invenio_communities/views/decorators.py
+++ b/invenio_communities/views/decorators.py
@@ -10,7 +10,7 @@
 
 from functools import wraps
 
-from flask import g
+from flask import g, request
 
 from invenio_communities.communities.resources.serializer import (
     UICommunityJSONSerializer,
@@ -29,6 +29,7 @@ def pass_community(serialize):
                 id_=pid_value, identity=g.identity
             )
             kwargs["community"] = community
+            request.community = community.to_dict()
             if serialize:
                 community_ui = UICommunityJSONSerializer().dump_obj(community.to_dict())
                 kwargs["community_ui"] = community_ui


### PR DESCRIPTION
Closes https://github.com/zenodo/rdm-project/issues/172, closes https://github.com/inveniosoftware/invenio-app-rdm/issues/2327

- Removes "about" and/or "curation policy" tabs if no content
- Removes hard coded headline for Curation policy

No page contents added:
<img width="971" alt="Screenshot 2023-08-14 at 15 34 35" src="https://github.com/inveniosoftware/invenio-communities/assets/21052053/3f74b9f5-2ca6-4a88-86df-68763dee0262">
Only curation policy content added:
<img width="1078" alt="Screenshot 2023-08-14 at 15 35 11" src="https://github.com/inveniosoftware/invenio-communities/assets/21052053/a3f82d48-848d-46ea-b7fd-c07bbe43d362">
Both added:
<img width="1081" alt="Screenshot 2023-08-14 at 15 35 41" src="https://github.com/inveniosoftware/invenio-communities/assets/21052053/adc1f22e-fc43-4855-b0aa-fa7c92e30620">
