### PR TITLE
ui: safely render community `description`

### DIFF
--- a/invenio_communities/assets/semantic-ui/js/invenio_communities/community/communitiesItems/CommunityCompactItemComputer.js
+++ b/invenio_communities/assets/semantic-ui/js/invenio_communities/community/communitiesItems/CommunityCompactItemComputer.js
@@ -42,12 +42,9 @@ export const CommunityCompactItemComputer = ({
           </a>
 
           {metadata.description && (
-            <p
-              className="truncate-lines-1 text size small text-muted mt-5 rel-mb-1"
-              dangerouslySetInnerHTML={{
-                __html: _truncate(metadata.description, { length: 50 }),
-              }}
-            />
+            <p className="truncate-lines-1 text size small text-muted mt-5 rel-mb-1">
+              {_truncate(metadata.description, { length: 50 })}
+            </p>
           )}
 
           {(result.access.visibility === "restricted" ||

--- a/invenio_communities/assets/semantic-ui/js/invenio_communities/community/communitiesItems/CommunityCompactItemMobile.js
+++ b/invenio_communities/assets/semantic-ui/js/invenio_communities/community/communitiesItems/CommunityCompactItemMobile.js
@@ -63,12 +63,9 @@ export const CommunityCompactItemMobile = ({
 
       <div className="full-width">
         {metadata.description && (
-          <p
-            className="truncate-lines-1 text size small text-muted mt-5 rel-mb-1"
-            dangerouslySetInnerHTML={{
-              __html: _truncate(metadata.description, { length: 50 }),
-            }}
-          />
+          <p className="truncate-lines-1 text size small text-muted mt-5 rel-mb-1">
+            {_truncate(metadata.description, { length: 50 })}
+          </p>
         )}
 
         {(result.access.visibility === "restricted" ||

--- a/invenio_communities/assets/semantic-ui/js/invenio_communities/community/communitiesItems/CommunityItemComputer.js
+++ b/invenio_communities/assets/semantic-ui/js/invenio_communities/community/communitiesItems/CommunityItemComputer.js
@@ -42,12 +42,9 @@ export const CommunityItemComputer = ({ result }) => {
               {result.metadata.title}
             </a>
             {result.metadata.description && (
-              <p
-                className="truncate-lines-1 text size small text-muted mt-5"
-                dangerouslySetInnerHTML={{
-                  __html: result.metadata.description,
-                }}
-              />
+              <p className="truncate-lines-1 text size small text-muted mt-5">
+                {result.metadata.description}
+              </p>
             )}
 
             {(communityType ||

--- a/invenio_communities/assets/semantic-ui/js/invenio_communities/community/communitiesItems/CommunityItemMobile.js
+++ b/invenio_communities/assets/semantic-ui/js/invenio_communities/community/communitiesItems/CommunityItemMobile.js
@@ -73,12 +73,9 @@ export const CommunityItemMobile = ({ result, index }) => {
       {result.metadata.description && (
         <Grid.Row className="pt-0">
           <Grid.Column width={16} className="pl-0 pr-0">
-            <p
-              className="truncate-lines-1 text size small text-muted mt-5"
-              dangerouslySetInnerHTML={{
-                __html: result.metadata.description,
-              }}
-            />
+            <p className="truncate-lines-1 text size small text-muted mt-5">
+              {result.metadata.description}
+            </p>
           </Grid.Column>
         </Grid.Row>
       )}

--- a/invenio_communities/assets/semantic-ui/js/invenio_communities/community/frontpage.js
+++ b/invenio_communities/assets/semantic-ui/js/invenio_communities/community/frontpage.js
@@ -80,12 +80,7 @@ class CommunityCard extends Component {
           </Card.Header>
           {community.metadata.description && (
             <Card.Description>
-              <div
-                className="truncate-lines-2"
-                dangerouslySetInnerHTML={{
-                  __html: community.metadata.description,
-                }}
-              />
+              <div className="truncate-lines-2">{community.metadata.description}</div>
             </Card.Description>
           )}
         </Card.Content>

--- a/invenio_communities/assets/semantic-ui/js/invenio_communities/community/searchComponents/ResultsGridItemTemplate.js
+++ b/invenio_communities/assets/semantic-ui/js/invenio_communities/community/searchComponents/ResultsGridItemTemplate.js
@@ -8,12 +8,7 @@ export const ResultsGridItemTemplate = ({ result }) => {
       <Card.Content>
         <Card.Header>{result.metadata.title}</Card.Header>
         <Card.Description>
-          <div
-            className="truncate-lines-2"
-            dangerouslySetInnerHTML={{
-              __html: result.metadata.description,
-            }}
-          />
+          <div className="truncate-lines-2">{result.metadata.description}</div>
         </Card.Description>
       </Card.Content>
     </Card>

--- a/invenio_communities/assets/semantic-ui/js/invenio_communities/members/invitations/InvitationResultItem.js
+++ b/invenio_communities/assets/semantic-ui/js/invenio_communities/members/invitations/InvitationResultItem.js
@@ -59,12 +59,7 @@ export class InvitationResultItem extends Component {
                   </Item.Header>
                   {member.description && (
                     <Item.Meta>
-                      <div
-                        className="truncate-lines-1"
-                        dangerouslySetInnerHTML={{
-                          __html: member.description,
-                        }}
-                      />
+                      <div className="truncate-lines-1">{member.description}</div>
                     </Item.Meta>
                   )}
                 </Item.Content>

--- a/invenio_communities/assets/semantic-ui/js/invenio_communities/members/members/components/MembersResultsGridItem.js
+++ b/invenio_communities/assets/semantic-ui/js/invenio_communities/members/members/components/MembersResultsGridItem.js
@@ -16,12 +16,7 @@ export function MembersResultsGridItem({ result }) {
       <Card.Content>
         <Card.Header>{result.member.name}</Card.Header>
         <Card.Description>
-          <div
-            className="truncate-lines-1"
-            dangerouslySetInnerHTML={{
-              __html: result.member.description,
-            }}
-          />
+          <div className="truncate-lines-1">{result.member.description}</div>
         </Card.Description>
       </Card.Content>
     </Card>

--- a/invenio_communities/assets/semantic-ui/js/invenio_communities/members/members/manager_view/ManagerMembersResultItem.js
+++ b/invenio_communities/assets/semantic-ui/js/invenio_communities/members/members/manager_view/ManagerMembersResultItem.js
@@ -100,12 +100,9 @@ export class ManagerMembersResultItem extends Component {
                   </Item.Header>
                   {result.member.description && (
                     <Item.Meta>
-                      <div
-                        className="truncate-lines-1"
-                        dangerouslySetInnerHTML={{
-                          __html: result.member.description,
-                        }}
-                      />
+                      <div className="truncate-lines-1">
+                        {result.member.description}
+                      </div>
                     </Item.Meta>
                   )}
                 </Item.Content>

--- a/invenio_communities/assets/semantic-ui/js/invenio_communities/members/members/public_view/PublicMembersResultItem.js
+++ b/invenio_communities/assets/semantic-ui/js/invenio_communities/members/members/public_view/PublicMembersResultItem.js
@@ -28,12 +28,9 @@ class PublicMemberPublicViewResultItem extends Component {
                   </Item.Header>
                   {result.member.description && (
                     <Item.Meta>
-                      <div
-                        className="truncate-lines-1"
-                        dangerouslySetInnerHTML={{
-                          __html: result.member.description,
-                        }}
-                      />
+                      <div className="truncate-lines-1">
+                        {result.member.description}
+                      </div>
                     </Item.Meta>
                   )}
                 </Item.Content>

--- a/invenio_communities/assets/semantic-ui/js/invenio_communities/settings/profile/CommunityProfileForm.js
+++ b/invenio_communities/assets/semantic-ui/js/invenio_communities/settings/profile/CommunityProfileForm.js
@@ -46,8 +46,8 @@ const COMMUNITY_VALIDATION_SCHEMA = Yup.object({
   metadata: Yup.object({
     title: Yup.string().max(250, i18next.t("Maximum number of characters is 2000")),
     description: Yup.string().max(
-      2000,
-      i18next.t("Maximum number of characters is 2000")
+      250,
+      i18next.t("Maximum number of characters is 250")
     ),
     website: Yup.string().url(i18next.t("Must be a valid URL")),
     type: Yup.object().shape({

--- a/invenio_communities/communities/schema.py
+++ b/invenio_communities/communities/schema.py
@@ -115,7 +115,7 @@ class CommunityMetadataSchema(Schema):
     """Community metadata schema."""
 
     title = SanitizedUnicode(required=True, validate=_not_blank(max=250))
-    description = SanitizedUnicode(validate=_not_blank(max=2000))
+    description = SanitizedUnicode(validate=_not_blank(max=250))
 
     curation_policy = SanitizedHTML(validate=no_longer_than(max=2000))
     page = SanitizedHTML(validate=no_longer_than(max=2000))

--- a/invenio_communities/fixtures/demo.py
+++ b/invenio_communities/fixtures/demo.py
@@ -23,7 +23,7 @@ def create_fake_community(faker):
         "slug": faker.unique.domain_word(),
         "metadata": {
             "title": faker.sentence(nb_words=5, variable_nb_words=True),
-            "description": faker.text(max_nb_chars=2000),
+            "description": faker.text(max_nb_chars=250),
             "type": {
                 "id": random.choice(["organization", "event", "topic", "project"])
             },


### PR DESCRIPTION
* Closes https://github.com/inveniosoftware/invenio-app-rdm/issues/2216.
* Removes all unsafe rendering of community description as HTML.
* Limits the max length of a community description to 250 chars.
