### PR TITLE
CommunityCompactItem: add external icon and target blank

### DIFF
--- a/invenio_communities/assets/semantic-ui/js/invenio_communities/community/communitiesItems/CommunityCompactItemComputer.js
+++ b/invenio_communities/assets/semantic-ui/js/invenio_communities/community/communitiesItems/CommunityCompactItemComputer.js
@@ -37,10 +37,18 @@ export const CommunityCompactItemComputer = ({
         />
 
         <div>
-          <a href={links.self_html} className="ui small header truncate-lines-2">
-            {metadata.title}
-          </a>
-
+          <div className="flex align-items-center rel-mb-1">
+            <a
+              href={links.self_html}
+              className="ui small header truncate-lines-2 m-0 mr-5"
+              target="_blank"
+              rel="noreferrer"
+              aria-label={`${metadata.title} (${i18next.t("opens in new tab")})`}
+            >
+              {metadata.title}
+            </a>
+            <i className="small icon external primary" aria-hidden="true" />
+          </div>
           {metadata.description && (
             <p
               className="truncate-lines-1 text size small text-muted mt-5 rel-mb-1"

--- a/invenio_communities/assets/semantic-ui/js/invenio_communities/community/communitiesItems/CommunityCompactItemMobile.js
+++ b/invenio_communities/assets/semantic-ui/js/invenio_communities/community/communitiesItems/CommunityCompactItemMobile.js
@@ -34,10 +34,17 @@ export const CommunityCompactItemMobile = ({
             className="community-image rel-mr-1"
           />
 
-          <div>
-            <a href={links.self_html} className="ui small header truncate-lines-2">
+          <div className="flex align-items-center rel-mb-1">
+            <a
+              href={links.self_html}
+              className="ui small header truncate-lines-2 m-0 mr-5"
+              target="_blank"
+              rel="noreferrer"
+              aria-label={`${metadata.title} (${i18next.t("opens in new tab")})`}
+            >
               {metadata.title}
             </a>
+            <i className="small icon external primary" aria-hidden="true" />
           </div>
         </div>
 


### PR DESCRIPTION
Closes https://github.com/inveniosoftware/invenio-app-rdm/issues/2420

I added the icon as suggested in the issue, rather than the other suggestion of making the link select the community. I think this is the most intuitive behavior, as we have a select button on the item - it is also useful to have a way to view the community before selecting.

<img width="819" alt="Screenshot 2023-09-19 at 15 17 51" src="https://github.com/inveniosoftware/invenio-communities/assets/21052053/1b513abb-8021-4b21-9c97-eb470a2acd69">
