### PR TITLE
translations: fix ngettext parameter

### DIFF
--- a/invenio_communities/errors.py
+++ b/invenio_communities/errors.py
@@ -52,8 +52,8 @@ class OpenRequestsForCommunityDeletionError(CommunityError):
         """Initialise error."""
         super().__init__(
             ngettext(
-                "There is %(count)s request open for this community. Please, resolve it before deleting this community.",
-                "There are %(count)s requests open for this community. Please, resolve all of them before deleting this community.",
+                "There is %(num)s request open for this community. Please, resolve it before deleting this community.",
+                "There are %(num)s requests open for this community. Please, resolve all of them before deleting this community.",
                 requests,
             )
         )


### PR DESCRIPTION
* closes https://github.com/zenodo/rdm-project/issues/492

Asks for a `num`: https://github.com/python-babel/flask-babel/blob/master/flask_babel/__init__.py#L662

<img width="618" alt="Screenshot 2023-10-31 at 19 09 34" src="https://github.com/inveniosoftware/invenio-communities/assets/61321254/a910181f-7317-43a8-a48b-39109d201f82">
<img width="637" alt="Screenshot 2023-10-31 at 19 17 37" src="https://github.com/inveniosoftware/invenio-communities/assets/61321254/9dfe985d-c220-47af-93a5-9c44bfa35f8f">
