### PR TITLE
views: Conditional New Community btn visibility

### DIFF
--- a/invenio_communities/config.py
+++ b/invenio_communities/config.py
@@ -3,6 +3,7 @@
 # This file is part of Invenio.
 # Copyright (C) 2016-2022 CERN.
 # Copyright (C) 2023 Graz University of Technology.
+# Copyright (C) 2023 KTH Royal Institute of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -312,3 +313,6 @@ COMMUNITIES_IDENTITIES_CACHE_HANDLER = (
 )
 
 COMMUNITIES_OAI_SETS_PREFIX = "community-"
+
+COMMUNITIES_ALWAYS_SHOW_CREATE_LINK = False
+"""Controls visibility of 'New Community' btn based on user's permission when set to True."""

--- a/invenio_communities/views/ui.py
+++ b/invenio_communities/views/ui.py
@@ -3,6 +3,7 @@
 # This file is part of Invenio.
 # Copyright (C) 2016-2021 CERN.
 # Copyright (C) 2023 Graz University of Technology.
+# Copyright (C) 2023 KTH Royal Institute of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -83,8 +84,21 @@ def record_permission_denied_error(error):
 
 def _can_create_community():
     """Function used to check if a user has permissions to create a community."""
-    can_create = current_communities.service.check_permission(g.identity, "create")
-    return can_create
+    return current_communities.service.check_permission(g.identity, "create")
+
+
+def _show_create_community_link():
+    """
+    Determine if the 'New community' button should always be visible.
+
+    If the 'COMMUNITIES_ALWAYS_SHOW_CREATE_LINK' config is False,
+    check the user's permission to create a community link. If the config is
+    True, the button is always visible.
+    """
+    should_show = current_app.config.get("COMMUNITIES_ALWAYS_SHOW_CREATE_LINK", False)
+    if not should_show:  # show only when user can create
+        should_show = _can_create_community()
+    return should_show
 
 
 def _has_about_page_content():
@@ -192,6 +206,7 @@ def create_ui_blueprint(app):
             "invenio_communities.communities_new",
             _("New community"),
             order=3,
+            visible_when=_show_create_community_link,
         )
 
         communities = current_menu.submenu("communities")

--- a/tests/communities/tests_views.py
+++ b/tests/communities/tests_views.py
@@ -1,13 +1,19 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2022 CERN.
+# Copyright (C) 2023 KTH Royal Institute of Technology.
 #
 # Invenio-Communities is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more details.
 
 """Test community views."""
 
+from flask import g
+from invenio_records_permissions.generators import SystemProcess
+
+from invenio_communities.permissions import CommunityPermissionPolicy
 from invenio_communities.views.communities import _filter_roles
+from invenio_communities.views.ui import _show_create_community_link
 
 
 def _test_filter_roles(app, members, action, member_types, community_id):
@@ -60,3 +66,33 @@ def test_filter_roles_when_adding_groups(
         {"group"},
         community.id,
     )
+
+
+def test_show_create_community_link(app, users, superuser_identity):
+    """Test the _can_create_community function under different config settings."""
+    test_users = ["reader", "curator", "manager", "owner"]
+    ALWAYS_SHOW_CREATE_LINK = "COMMUNITIES_ALWAYS_SHOW_CREATE_LINK"
+
+    # Test default config allows community creation
+    assert app.config.get(ALWAYS_SHOW_CREATE_LINK) == False
+    assert _show_create_community_link() == True
+
+    # Test with config set to True
+    app.config[ALWAYS_SHOW_CREATE_LINK] = True
+    assert app.config.get(ALWAYS_SHOW_CREATE_LINK) == True
+    assert _show_create_community_link() == True
+
+    # Test with different user identities
+    for user in test_users:
+        g.identity = users[user].identity
+        assert _show_create_community_link() == True
+
+    # Test with community creation disabled
+    CommunityPermissionPolicy.can_create = [SystemProcess()]
+    for user in test_users:
+        g.identity = users[user].identity
+        assert _show_create_community_link() == False
+
+    # Test superuser
+    g.identity = superuser_identity
+    assert _show_create_community_link() == True


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description
This update introduces a configurable option to control the visibility of the 'New Community' menu button in InvenioRDM based on user permissions and application configuration. When the corresponding configuration (COMMUNITIES_CREATE_PERM_CHECK) is set to false, the 'New Community' button is always visible to users. If set to true, the system checks whether the user has the necessary permission to create a community before displaying the button. This feature enhances administrative control and personalizes the user interface according to user roles and permissions.

Note: This functionality was previously enabled but encountered issues in Zenodo, leading to its temporary disablement. 

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/best-practices/i18n/) (for relevant code).
- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines (for relevant code).
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines (for relevant code).
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines (for relevant code).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).

**Third-party code**

If you've added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
