### PR TITLE
frontpage: split component definition and app rendering [+]

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,12 @@
 Changes
 =======
 
+Version 7.18.0 (released 2023-11-10)
+
+- split CommunitiesCardGroup definition and rendering
+- changed "featured-communities" id on communities frontpage to "new-communities".
+  WARNING: If you are overriding invenio-communities/frontpage.html, make that change in your template.
+
 Version 7.17.0 (released 2023-11-10)
 
 - assets: add overridable id to profile form

--- a/invenio_communities/assets/semantic-ui/js/invenio_communities/community/CommunitiesCardGroup.js
+++ b/invenio_communities/assets/semantic-ui/js/invenio_communities/community/CommunitiesCardGroup.js
@@ -1,0 +1,171 @@
+/*
+ * This file is part of Invenio.
+ * Copyright (C) 2016-2021 CERN.
+ * Copyright (C) 2023 Northwestern University.
+ *
+ * Invenio is free software; you can redistribute it and/or modify it
+ * under the terms of the MIT License; see LICENSE file for more details.
+ */
+
+import _truncate from "lodash/truncate";
+import React, { Component } from "react";
+import { Image, withCancel } from "react-invenio-forms";
+import { Card, Grid, Message, Placeholder } from "semantic-ui-react";
+import { http } from "react-invenio-forms";
+import PropTypes from "prop-types";
+
+const PlaceholderLoader = ({ size, isLoading, children, ...props }) => {
+  const PlaceholderItem = () => (
+    <Grid.Column width={3}>
+      <Placeholder>
+        <Placeholder.Image square />
+      </Placeholder>
+      <Placeholder>
+        <Placeholder.Paragraph>
+          <Placeholder.Line length="medium" />
+          <Placeholder.Line length="short" />
+        </Placeholder.Paragraph>
+      </Placeholder>
+    </Grid.Column>
+  );
+  let numberOfHeader = [];
+  for (let i = 0; i < size; i++) {
+    numberOfHeader.push(<PlaceholderItem key={i} />);
+  }
+
+  if (!isLoading) {
+    return children;
+  }
+  return (
+    <Grid columns="equal" stackable>
+      {numberOfHeader}
+    </Grid>
+  );
+};
+
+PlaceholderLoader.propTypes = {
+  size: PropTypes.number,
+  isLoading: PropTypes.bool.isRequired,
+  children: PropTypes.node.isRequired,
+};
+
+PlaceholderLoader.defaultProps = {
+  size: 5,
+};
+
+const EmptyMessage = ({ message }) => {
+  return <Message icon="info" header={message} />;
+};
+
+EmptyMessage.propTypes = {
+  message: PropTypes.string.isRequired,
+};
+
+class CommunityCard extends Component {
+  render() {
+    const { community, defaultLogo } = this.props;
+    return (
+      <Card fluid href={`/communities/${community.slug}`}>
+        <Image
+          wrapped
+          centered
+          ui={false}
+          src={community.links.logo}
+          fallbackSrc={defaultLogo}
+          loadFallbackFirst
+        />
+        <Card.Content>
+          <Card.Header>
+            {_truncate(community.metadata.title, { length: 30 })}
+          </Card.Header>
+          {community.metadata.description && (
+            <Card.Description>
+              <div className="truncate-lines-2">{community.metadata.description}</div>
+            </Card.Description>
+          )}
+        </Card.Content>
+      </Card>
+    );
+  }
+}
+
+CommunityCard.propTypes = {
+  community: PropTypes.object.isRequired,
+  defaultLogo: PropTypes.string.isRequired,
+};
+
+class CommunitiesCardGroup extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      isLoading: false,
+      data: { hits: [] },
+    };
+  }
+
+  componentDidMount() {
+    this.fetchData();
+  }
+
+  componentWillUnmount() {
+    this.cancellableFetch && this.cancellableFetch.cancel();
+  }
+
+  fetchData = async () => {
+    const { fetchDataUrl } = this.props;
+    this.setState({ isLoading: true });
+    this.cancellableFetch = withCancel(http.get(fetchDataUrl));
+
+    try {
+      const response = await this.cancellableFetch.promise;
+
+      this.setState({ data: response.data.hits, isLoading: false });
+    } catch (error) {
+      // TODO: handle error response
+    }
+  };
+
+  renderCards() {
+    const { data } = this.state;
+    const { defaultLogo } = this.props;
+
+    return data.hits.map((community) => {
+      return (
+        <CommunityCard
+          key={community.id}
+          community={community}
+          defaultLogo={defaultLogo}
+        />
+      );
+    });
+  }
+
+  render() {
+    const { isLoading, data } = this.state;
+    const { emptyMessage } = this.props;
+    return (
+      <PlaceholderLoader isLoading={isLoading}>
+        {data.hits.length === 0 ? (
+          <EmptyMessage message={emptyMessage} />
+        ) : (
+          <Card.Group
+            doubling
+            stackable
+            itemsPerRow={5}
+            className="community-frontpage-cards"
+          >
+            {this.renderCards()}
+          </Card.Group>
+        )}
+      </PlaceholderLoader>
+    );
+  }
+}
+
+CommunitiesCardGroup.propTypes = {
+  fetchDataUrl: PropTypes.string.isRequired,
+  defaultLogo: PropTypes.string.isRequired,
+  emptyMessage: PropTypes.string.isRequired,
+};
+
+export default CommunitiesCardGroup;

--- a/invenio_communities/assets/semantic-ui/js/invenio_communities/community/frontpage.js
+++ b/invenio_communities/assets/semantic-ui/js/invenio_communities/community/frontpage.js
@@ -1,175 +1,19 @@
 /*
  * This file is part of Invenio.
  * Copyright (C) 2016-2021 CERN.
+ * Copyright (C) 2023 Northwestern University.
  *
  * Invenio is free software; you can redistribute it and/or modify it
  * under the terms of the MIT License; see LICENSE file for more details.
  */
 
-import _truncate from "lodash/truncate";
-import React, { Component } from "react";
+import React from "react";
 import ReactDOM from "react-dom";
-import { Image, withCancel } from "react-invenio-forms";
-import { Card, Grid, Message, Placeholder } from "semantic-ui-react";
-import { http } from "react-invenio-forms";
-import PropTypes from "prop-types";
 
-const PlaceholderLoader = ({ size, isLoading, children, ...props }) => {
-  const PlaceholderItem = () => (
-    <Grid.Column width={3}>
-      <Placeholder>
-        <Placeholder.Image square />
-      </Placeholder>
-      <Placeholder>
-        <Placeholder.Paragraph>
-          <Placeholder.Line length="medium" />
-          <Placeholder.Line length="short" />
-        </Placeholder.Paragraph>
-      </Placeholder>
-    </Grid.Column>
-  );
-  let numberOfHeader = [];
-  for (let i = 0; i < size; i++) {
-    numberOfHeader.push(<PlaceholderItem key={i} />);
-  }
-
-  if (!isLoading) {
-    return children;
-  }
-  return (
-    <Grid columns="equal" stackable>
-      {numberOfHeader}
-    </Grid>
-  );
-};
-
-PlaceholderLoader.propTypes = {
-  size: PropTypes.number,
-  isLoading: PropTypes.bool.isRequired,
-  children: PropTypes.node.isRequired,
-};
-
-PlaceholderLoader.defaultProps = {
-  size: 5,
-};
-
-const EmptyMessage = ({ message }) => {
-  return <Message icon="info" header={message} />;
-};
-
-EmptyMessage.propTypes = {
-  message: PropTypes.string.isRequired,
-};
-
-class CommunityCard extends Component {
-  render() {
-    const { community, defaultLogo } = this.props;
-    return (
-      <Card fluid href={`/communities/${community.slug}`}>
-        <Image
-          wrapped
-          centered
-          ui={false}
-          src={community.links.logo}
-          fallbackSrc={defaultLogo}
-          loadFallbackFirst
-        />
-        <Card.Content>
-          <Card.Header>
-            {_truncate(community.metadata.title, { length: 30 })}
-          </Card.Header>
-          {community.metadata.description && (
-            <Card.Description>
-              <div className="truncate-lines-2">{community.metadata.description}</div>
-            </Card.Description>
-          )}
-        </Card.Content>
-      </Card>
-    );
-  }
-}
-
-CommunityCard.propTypes = {
-  community: PropTypes.object.isRequired,
-  defaultLogo: PropTypes.string.isRequired,
-};
-
-class CommunitiesCardGroup extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      isLoading: false,
-      data: { hits: [] },
-    };
-  }
-
-  componentDidMount() {
-    this.fetchData();
-  }
-
-  componentWillUnmount() {
-    this.cancellableFetch && this.cancellableFetch.cancel();
-  }
-
-  fetchData = async () => {
-    const { fetchDataUrl } = this.props;
-    this.setState({ isLoading: true });
-    this.cancellableFetch = withCancel(http.get(fetchDataUrl));
-
-    try {
-      const response = await this.cancellableFetch.promise;
-
-      this.setState({ data: response.data.hits, isLoading: false });
-    } catch (error) {
-      // TODO: handle error response
-    }
-  };
-
-  renderCards() {
-    const { data } = this.state;
-    const { defaultLogo } = this.props;
-
-    return data.hits.map((community) => {
-      return (
-        <CommunityCard
-          key={community.id}
-          community={community}
-          defaultLogo={defaultLogo}
-        />
-      );
-    });
-  }
-
-  render() {
-    const { isLoading, data } = this.state;
-    const { emptyMessage } = this.props;
-    return (
-      <PlaceholderLoader isLoading={isLoading}>
-        {data.hits.length === 0 ? (
-          <EmptyMessage message={emptyMessage} />
-        ) : (
-          <Card.Group
-            doubling
-            stackable
-            itemsPerRow={5}
-            className="community-frontpage-cards"
-          >
-            {this.renderCards()}
-          </Card.Group>
-        )}
-      </PlaceholderLoader>
-    );
-  }
-}
-
-CommunitiesCardGroup.propTypes = {
-  fetchDataUrl: PropTypes.string.isRequired,
-  defaultLogo: PropTypes.string.isRequired,
-  emptyMessage: PropTypes.string.isRequired,
-};
+import CommunitiesCardGroup from "./CommunitiesCardGroup";
 
 const userCommunitiesContainer = document.getElementById("user-communities");
-const featuredCommunitiesContainer = document.getElementById("featured-communities");
+const newCommunitiesContainer = document.getElementById("new-communities");
 
 if (userCommunitiesContainer) {
   ReactDOM.render(
@@ -181,12 +25,14 @@ if (userCommunitiesContainer) {
     userCommunitiesContainer
   );
 }
-ReactDOM.render(
-  <CommunitiesCardGroup
-    fetchDataUrl="/api/communities?q=&sort=newest&page=1&size=5"
-    emptyMessage="There are no featured communities."
-    defaultLogo="/static/images/square-placeholder.png"
-  />,
-  featuredCommunitiesContainer
-);
-export default CommunitiesCardGroup;
+
+if (newCommunitiesContainer) {
+  ReactDOM.render(
+    <CommunitiesCardGroup
+      fetchDataUrl="/api/communities?q=&sort=newest&page=1&size=5"
+      emptyMessage="There are no new communities."
+      defaultLogo="/static/images/square-placeholder.png"
+    />,
+    newCommunitiesContainer
+  );
+}

--- a/invenio_communities/templates/semantic-ui/invenio_communities/frontpage.html
+++ b/invenio_communities/templates/semantic-ui/invenio_communities/frontpage.html
@@ -84,6 +84,6 @@
       </a>
   </div>
   <div class="ui divider hidden"></div>
-  <div id="featured-communities"></div>
+  <div id="new-communities"></div>
 </div>
 {%- endblock page_body %}


### PR DESCRIPTION
By decoupling the CommunitiesCardGroup definition and its ReactDOM.render, other
code can reuse the component independently.

Also renames featured-communities to new-communities because that's what it is.
