### PR TITLE
mappings: change "dynamic" values to string

### DIFF
--- a/invenio_communities/communities/records/mappings/os-v1/communities/communities-v1.0.0.json
+++ b/invenio_communities/communities/records/mappings/os-v1/communities/communities-v1.0.0.json
@@ -62,7 +62,7 @@
               },
               "title": {
                 "type": "object",
-                "dynamic": true
+                "dynamic": "true"
               }
             }
           },
@@ -135,7 +135,7 @@
               },
               "title": {
                 "type": "object",
-                "dynamic": true,
+                "dynamic": "true",
                 "properties": {
                   "en": {
                     "type": "text"
@@ -177,7 +177,7 @@
                   },
                   "title": {
                     "type": "object",
-                    "dynamic": true
+                    "dynamic": "true"
                   },
                   "number": {
                     "type": "text",
@@ -312,7 +312,7 @@
                   },
                   "title": {
                     "type": "object",
-                    "dynamic": true,
+                    "dynamic": "true",
                     "properties": {
                       "en": {
                         "type": "text"
@@ -351,7 +351,7 @@
                       },
                       "title": {
                         "type": "object",
-                        "dynamic": true
+                        "dynamic": "true"
                       },
                       "number": {
                         "type": "text",

--- a/invenio_communities/communities/records/mappings/os-v2/communities/communities-v1.0.0.json
+++ b/invenio_communities/communities/records/mappings/os-v2/communities/communities-v1.0.0.json
@@ -62,7 +62,7 @@
               },
               "title": {
                 "type": "object",
-                "dynamic": true
+                "dynamic": "true"
               }
             }
           },
@@ -135,7 +135,7 @@
               },
               "title": {
                 "type": "object",
-                "dynamic": true,
+                "dynamic": "true",
                 "properties": {
                   "en": {
                     "type": "text"
@@ -177,7 +177,7 @@
                   },
                   "title": {
                     "type": "object",
-                    "dynamic": true
+                    "dynamic": "true"
                   },
                   "number": {
                     "type": "text",
@@ -306,7 +306,7 @@
               },
               "title": {
                 "type": "object",
-                "dynamic": true,
+                "dynamic": "true",
                 "properties": {
                   "en": {
                     "type": "text"
@@ -332,7 +332,7 @@
                   },
                   "title": {
                     "type": "object",
-                    "dynamic": true,
+                    "dynamic": "true",
                     "properties": {
                       "en": {
                         "type": "text"
@@ -371,7 +371,7 @@
                       },
                       "title": {
                         "type": "object",
-                        "dynamic": true
+                        "dynamic": "true"
                       },
                       "number": {
                         "type": "text",

--- a/invenio_communities/communities/records/mappings/v7/communities/communities-v1.0.0.json
+++ b/invenio_communities/communities/records/mappings/v7/communities/communities-v1.0.0.json
@@ -62,7 +62,7 @@
               },
               "title": {
                 "type": "object",
-                "dynamic": true
+                "dynamic": "true"
               }
             }
           },
@@ -135,7 +135,7 @@
               },
               "title": {
                 "type": "object",
-                "dynamic": true,
+                "dynamic": "true",
                 "properties": {
                   "en": {
                     "type": "text"
@@ -177,7 +177,7 @@
                   },
                   "title": {
                     "type": "object",
-                    "dynamic": true
+                    "dynamic": "true"
                   },
                   "number": {
                     "type": "text",
@@ -312,7 +312,7 @@
                   },
                   "title": {
                     "type": "object",
-                    "dynamic": true,
+                    "dynamic": "true",
                     "properties": {
                       "en": {
                         "type": "text"
@@ -351,7 +351,7 @@
                       },
                       "title": {
                         "type": "object",
-                        "dynamic": true
+                        "dynamic": "true"
                       },
                       "number": {
                         "type": "text",


### PR DESCRIPTION
- The mapping is stored as a string/enum in ES/OS. Using the same type
  makes sure the mapping comparison is correct when performing a
  mapping update.
