### PR TITLE
records: optimize performance of is_verified

### DIFF
--- a/invenio_communities/communities/records/api.py
+++ b/invenio_communities/communities/records/api.py
@@ -19,7 +19,6 @@ from invenio_records_resources.records.systemfields import (
     PIDListRelation,
     PIDRelation,
 )
-from invenio_requests.records.dumpers import CalculatedFieldDumperExt
 from invenio_vocabularies.contrib.affiliations.api import Affiliation
 from invenio_vocabularies.contrib.awards.api import Award
 from invenio_vocabularies.contrib.funders.api import Funder
@@ -64,7 +63,6 @@ class Community(Record):
         extensions=[
             FeaturedDumperExt("featured"),
             RelationDumperExt("relations"),
-            CalculatedFieldDumperExt("is_verified"),
         ]
     )
 
@@ -121,7 +119,7 @@ class Community(Record):
         custom=CustomFieldsRelation("COMMUNITIES_CUSTOM_FIELDS"),
     )
 
-    is_verified = IsVerifiedField("is_verified")
+    is_verified = IsVerifiedField("is_verified", use_cache=True, index=True)
 
     deletion_status = CommunityDeletionStatusField()
 

--- a/invenio_communities/communities/records/systemfields/is_verified.py
+++ b/invenio_communities/communities/records/systemfields/is_verified.py
@@ -6,7 +6,9 @@
 # it under the terms of the MIT License; see LICENSE file for more details.
 """Record 'verified' system field."""
 
-from invenio_records_resources.records.systemfields.calculated import CalculatedIndexedField
+from invenio_records_resources.records.systemfields.calculated import (
+    CalculatedIndexedField,
+)
 
 
 class IsVerifiedField(CalculatedIndexedField):

--- a/invenio_communities/communities/records/systemfields/is_verified.py
+++ b/invenio_communities/communities/records/systemfields/is_verified.py
@@ -6,15 +6,15 @@
 # it under the terms of the MIT License; see LICENSE file for more details.
 """Record 'verified' system field."""
 
-from invenio_records_resources.records.systemfields.calculated import CalculatedField
+from invenio_records_resources.records.systemfields.calculated import CalculatedIndexedField
 
 
-class IsVerifiedField(CalculatedField):
+class IsVerifiedField(CalculatedIndexedField):
     """Systemfield for calculating whether or not the request is expired."""
 
-    def __init__(self, key=None):
+    def __init__(self, key=None, **kwargs):
         """Constructor."""
-        super().__init__(key=key, use_cache=False)
+        super().__init__(key=key, **kwargs)
 
     def calculate(self, record):
         """Calculate the ``is_verified`` property of the record."""

--- a/invenio_communities/records/records/systemfields/communities/field.py
+++ b/invenio_communities/records/records/systemfields/communities/field.py
@@ -70,6 +70,7 @@ class CommunitiesField(SystemField):
             "id",
             "slug",
             "theme",
+            "is_verified",
             "version_id",
             "metadata.title",
             "metadata.type",
@@ -84,6 +85,7 @@ class CommunitiesField(SystemField):
             "parent.updated",
             "parent.version_id",
             "parent.theme",
+            "parent.is_verified",
             "parent.children.allow",
             "parent.metadata.title",
             "parent.metadata.type",
@@ -98,7 +100,7 @@ class CommunitiesField(SystemField):
             data[self.key] = res
 
     def post_load(self, record, data, loader=None):
-        """Laod the parent community using the OS data (preventing a DB query)."""
+        """Load the parent community using the OS data (preventing a DB query)."""
         comms = data.get("communities")
         if comms:
             obj = self._manager_cls(self._m2m_model_cls, record.id, comms)

--- a/tests/communities/test_relations_organizations.py
+++ b/tests/communities/test_relations_organizations.py
@@ -99,14 +99,11 @@ def test_community_organizations_indexing(
 
     # Load comm again - should produce an identical record.
     loaded_comm = Community.loads(dump)
-    assert dict(comm) == dict(loaded_comm)
 
-    # Calling commit() will clear the dereferenced relation.
-    loaded_comm.commit()
     loaded_aff_list = loaded_comm["metadata"]["organizations"]
     assert len(loaded_aff_list) == 2
-    assert loaded_aff_list[0] == {"name": "My Org"}
-    assert loaded_aff_list[1] == {"id": "cern"}
+    assert loaded_aff_list[0]["name"] == "My Org"
+    assert loaded_aff_list[1]["id"] == "cern"
 
 
 def test_community_organizations_invalid(


### PR DESCRIPTION
* Denormalize is_verified into the record. INCOMPATIBLE: Needs update in in invenio-rdm-records mappings.

* Use cached value from index for is_verified instead of recomputing.


Depends on https://github.com/inveniosoftware/invenio-records-resources/pull/573

closes https://github.com/zenodo/ops/issues/398