### PR TITLE
models: fix memberships querying

### DIFF
--- a/invenio_communities/members/records/models.py
+++ b/invenio_communities/members/records/models.py
@@ -83,6 +83,11 @@ class BaseMemberModel(RecordMetadataBase):
     @classmethod
     def query_memberships(cls, user_id=None, group_ids=None, active=True):
         """Query for (community,role)-pairs."""
+        # We don't want to leak "all" memberships, so we require at least one of the
+        # filters to be set.
+        if user_id is None and not group_ids:
+            return []
+
         q = db.session.query(cls.community_id, cls.role).filter(cls.active == active)
 
         user_filter = cls.user_id == user_id

--- a/tests/members/test_members_services.py
+++ b/tests/members/test_members_services.py
@@ -440,9 +440,17 @@ def test_search_members_restricted_as_group(
     assert res.total == 2
 
 
-def test_read_memberships(member_service, community, any_user, db, clean_index):
-    # empty at first
+def test_read_memberships(
+    member_service,
+    community,
+    any_user,
+    anon_identity,
+    db,
+    clean_index,
+):
+    # empty at first for both authenticated and anonymous user
     assert member_service.read_memberships(any_user.identity) == {"memberships": []}
+    assert member_service.read_memberships(anon_identity) == {"memberships": []}
     # add membership
     data = {
         "members": [{"type": "user", "id": str(any_user.id)}],
@@ -453,6 +461,8 @@ def test_read_memberships(member_service, community, any_user, db, clean_index):
     assert member_service.read_memberships(any_user.identity) == {
         "memberships": [(str(community._record.id), "reader")]
     }
+    # still empty for the anonynous user
+    assert member_service.read_memberships(anon_identity) == {"memberships": []}
 
 
 #


### PR DESCRIPTION
* Fixes an edge-case where if no filtering parameters are passed all
  community/role pairs are returned.
