### PR TITLE
[#855] 4) membership request flow frontend integration

### DIFF
--- a/invenio_communities/assets/semantic-ui/js/invenio_communities/api/CommunityLinksExtractor.js
+++ b/invenio_communities/assets/semantic-ui/js/invenio_communities/api/CommunityLinksExtractor.js
@@ -35,4 +35,12 @@ export class CommunityLinksExtractor {
     }
     return this.#urls.invitations;
   }
+
+  url(key) {
+    const urlOfKey = this.#urls[key];
+    if (!urlOfKey) {
+      throw TypeError(`"${key}" link missing from resource.`);
+    }
+    return urlOfKey;
+  }
 }

--- a/invenio_communities/assets/semantic-ui/js/invenio_communities/api/RequestLinksExtractor.js
+++ b/invenio_communities/assets/semantic-ui/js/invenio_communities/api/RequestLinksExtractor.js
@@ -1,0 +1,29 @@
+// This file is part of Invenio-communities
+// Copyright (C) 2024 Northwestern University.
+//
+// Invenio-communities is free software; you can redistribute it and/or modify it
+// under the terms of the MIT License; see LICENSE file for more details.
+
+export class RequestLinksExtractor {
+  #urls;
+
+  constructor(request) {
+    if (!request?.links) {
+      throw TypeError("Request resource links are undefined");
+    }
+    this.#urls = request.links;
+  }
+
+  url(key) {
+    const urlOfKey = this.#urls[key];
+    if (!urlOfKey) {
+      throw TypeError(`"${key}" link missing from resource.`);
+    }
+    return urlOfKey;
+  }
+
+  get userDiscussionUrl() {
+    const result = this.url("self_html");
+    return result.replace("/requests/", "/me/requests/");
+  }
+}

--- a/invenio_communities/assets/semantic-ui/js/invenio_communities/api/membershipRequests/api.js
+++ b/invenio_communities/assets/semantic-ui/js/invenio_communities/api/membershipRequests/api.js
@@ -1,0 +1,26 @@
+// This file is part of Invenio-communities
+// Copyright (C) 2022 CERN.
+// Copyright (C) 2024 Northwestern University.
+//
+// Invenio-communities is free software; you can redistribute it and/or modify it
+// under the terms of the MIT License; see LICENSE file for more details.
+
+import { CommunityLinksExtractor } from "../CommunityLinksExtractor";
+import { http } from "react-invenio-forms";
+
+/**
+ * API Client for community membership requests.
+ *
+ * It mostly uses the API links passed to it from initial community.
+ *
+ */
+export class CommunityMembershipRequestsApi {
+  constructor(community) {
+    this.community = community;
+    this.linksExtractor = new CommunityLinksExtractor(community);
+  }
+
+  requestMembership = async (payload) => {
+    return await http.post(this.linksExtractor.url("membership_requests"), payload);
+  };
+}

--- a/invenio_communities/assets/semantic-ui/js/invenio_communities/community/header/RequestMembershipButton.js
+++ b/invenio_communities/assets/semantic-ui/js/invenio_communities/community/header/RequestMembershipButton.js
@@ -1,0 +1,104 @@
+/*
+ * This file is part of Invenio.
+ * Copyright (C) 2024 CERN.
+ * Copyright (C) 2024 Northwestern University.
+ *
+ * Invenio is free software; you can redistribute it and/or modify it
+ * under the terms of the MIT License; see LICENSE file for more details.
+ */
+
+import { i18next } from "@translations/invenio_communities/i18next";
+import { Formik } from "formik";
+import PropTypes from "prop-types";
+import React, { useState } from "react";
+import { TextAreaField } from "react-invenio-forms";
+import { Button, Form, Modal } from "semantic-ui-react";
+
+export function RequestMembershipModal(props) {
+  const { isOpen, onClose } = props;
+
+  const onSubmit = async (values, { setSubmitting, setFieldError }) => {
+    // TODO: implement me
+    console.log("RequestMembershipModal.onSubmit(args) called");
+    console.log("TODO: implement me", arguments);
+  };
+
+  let confirmed = true;
+
+  return (
+    <Formik
+      initialValues={{
+        requestMembershipComment: "",
+      }}
+      onSubmit={onSubmit}
+    >
+      {({ values, isSubmitting, handleSubmit }) => (
+        <Modal
+          open={isOpen}
+          onClose={onClose}
+          size="small"
+          closeIcon
+          closeOnDimmerClick={false}
+        >
+          <Modal.Header>{i18next.t("Request Membership")}</Modal.Header>
+          <Modal.Content>
+            <Form>
+              <TextAreaField
+                fieldPath="requestMembershipComment"
+                label={i18next.t("Message to managers (optional)")}
+              />
+            </Form>
+          </Modal.Content>
+          <Modal.Actions>
+            <Button onClick={onClose} floated="left">
+              {i18next.t("Cancel")}
+            </Button>
+            <Button
+              onClick={(event) => {
+                // TODO: Implement me
+                console.log("RequestMembershipModal button clicked.");
+              }}
+              positive={confirmed}
+              primary
+            >
+              {i18next.t("Request Membership")}
+            </Button>
+          </Modal.Actions>
+        </Modal>
+      )}
+    </Formik>
+  );
+}
+
+RequestMembershipModal.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+};
+
+export function RequestMembershipButton(props) {
+  const [isModalOpen, setModalOpen] = useState(false);
+
+  const handleClick = () => {
+    setModalOpen(true);
+  };
+
+  const handleClose = () => {
+    setModalOpen(false);
+  };
+
+  return (
+    <>
+      <Button
+        name="request-membership"
+        onClick={handleClick}
+        positive
+        icon="sign-in"
+        labelPosition="left"
+        content={i18next.t("Request Membership")}
+      />
+      {isModalOpen && (
+        <RequestMembershipModal isOpen={isModalOpen} onClose={handleClose} />
+      )}
+    </>
+  );
+}

--- a/invenio_communities/assets/semantic-ui/js/invenio_communities/community/header/index.js
+++ b/invenio_communities/assets/semantic-ui/js/invenio_communities/community/header/index.js
@@ -1,0 +1,21 @@
+/*
+ * This file is part of Invenio.
+ * Copyright (C) 2024 Northwestern University.
+ *
+ * Invenio is free software; you can redistribute it and/or modify it
+ * under the terms of the MIT License; see LICENSE file for more details.
+ */
+
+import ReactDOM from "react-dom";
+
+import React from "react";
+
+import { RequestMembershipButton } from "./RequestMembershipButton";
+
+const domContainer = document.getElementById("request-membership-app");
+
+const community = JSON.parse(domContainer.dataset.community);
+
+if (domContainer) {
+  ReactDOM.render(<RequestMembershipButton community={community} />, domContainer);
+}

--- a/invenio_communities/assets/semantic-ui/js/invenio_communities/settings/privileges/index.js
+++ b/invenio_communities/assets/semantic-ui/js/invenio_communities/settings/privileges/index.js
@@ -1,4 +1,4 @@
-import CommunityPrivilegesForm from "./CommunityPriviledgesForm";
+import CommunityPrivilegesForm from "./CommunityPrivilegesForm";
 import ReactDOM from "react-dom";
 import React from "react";
 

--- a/invenio_communities/communities/services/config.py
+++ b/invenio_communities/communities/services/config.py
@@ -114,6 +114,9 @@ class CommunityServiceConfig(RecordServiceConfig, ConfiguratorMixin):
         "invitations": CommunityLink("{+api}/communities/{id}/invitations"),
         "requests": CommunityLink("{+api}/communities/{id}/requests"),
         "records": CommunityLink("{+api}/communities/{id}/records"),
+        "membership_requests": CommunityLink(
+            "{+api}/communities/{id}/membership-requests"
+        ),
     }
 
     action_link = CommunityLink(

--- a/invenio_communities/config.py
+++ b/invenio_communities/config.py
@@ -314,3 +314,6 @@ COMMUNITIES_OAI_SETS_PREFIX = "community-"
 
 COMMUNITIES_ALWAYS_SHOW_CREATE_LINK = False
 """Controls visibility of 'New Community' btn based on user's permission when set to True."""
+
+COMMUNITIES_ALLOW_MEMBERSHIP_REQUESTS = False
+"""Feature flag for membership request."""

--- a/invenio_communities/generators.py
+++ b/invenio_communities/generators.py
@@ -17,7 +17,7 @@ from functools import partial, reduce
 from itertools import chain
 
 from flask_principal import UserNeed
-from invenio_access.permissions import any_user, system_process
+from invenio_access.permissions import any_user, authenticated_user, system_process
 from invenio_records_permissions.generators import Generator
 from invenio_search.engine import dsl
 
@@ -199,6 +199,26 @@ class IfCommunityDeleted(Generator):
 #
 # Community membership generators
 #
+
+class AuthenticatedButNotCommunityMembers(Generator):
+    """Authenticated user not part of community."""
+
+    def needs(self, record=None, **kwargs):
+        """Required needs."""
+        return [authenticated_user]
+
+    def excludes(self, record=None, **kwargs):
+        """Exluding needs.
+
+        Excludes identities with a role in the community. This assumes all roles at
+        this point mean valid memberships. This is the same assumption as
+        `CommunityMembers` below.
+        """
+        if not record:
+            return []
+        community_id = str(record.id)
+        return [CommunityRoleNeed(community_id, r.name) for r in current_roles]
+
 class CommunityRoles(Generator):
     """Base class for community roles generators."""
 

--- a/invenio_communities/generators.py
+++ b/invenio_communities/generators.py
@@ -200,6 +200,7 @@ class IfCommunityDeleted(Generator):
 # Community membership generators
 #
 
+
 class AuthenticatedButNotCommunityMembers(Generator):
     """Authenticated user not part of community."""
 
@@ -218,6 +219,7 @@ class AuthenticatedButNotCommunityMembers(Generator):
             return []
         community_id = str(record.id)
         return [CommunityRoleNeed(community_id, r.name) for r in current_roles]
+
 
 class CommunityRoles(Generator):
     """Base class for community roles generators."""

--- a/invenio_communities/members/resources/config.py
+++ b/invenio_communities/members/resources/config.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2022 KTH Royal Institute of Technology
-# Copyright (C) 2022 Northwestern University.
+# Copyright (C) 2022-2024 Northwestern University.
 # Copyright (C) 2022 CERN.
 # Copyright (C) 2023 TU Wien.
 #
@@ -29,6 +29,7 @@ class MemberResourceConfig(RecordResourceConfig):
         "members": "/communities/<pid_value>/members",
         "publicmembers": "/communities/<pid_value>/members/public",
         "invitations": "/communities/<pid_value>/invitations",
+        "membership_requests": "/communities/<pid_value>/membership-requests",
     }
     request_view_args = {
         "pid_value": ma.fields.UUID(),

--- a/invenio_communities/members/resources/resource.py
+++ b/invenio_communities/members/resources/resource.py
@@ -31,10 +31,11 @@ class MemberResource(RecordResource):
             route("DELETE", routes["members"], self.delete),
             route("PUT", routes["members"], self.update),
             route("GET", routes["members"], self.search),
-            route("POST", routes["invitations"], self.invite),
             route("GET", routes["publicmembers"], self.search_public),
+            route("POST", routes["invitations"], self.invite),
             route("PUT", routes["invitations"], self.update_invitations),
             route("GET", routes["invitations"], self.search_invitations),
+            route("POST", routes["membership_requests"], self.request_membership),
         ]
 
     @request_view_args
@@ -97,6 +98,17 @@ class MemberResource(RecordResource):
             resource_requestctx.data,
         )
         return "", 204
+
+    @request_view_args
+    @request_data
+    def request_membership(self):
+        """Request membership."""
+        request = self.service.request_membership(
+            g.identity,
+            resource_requestctx.view_args["pid_value"],
+            resource_requestctx.data,
+        )
+        return request.to_dict(), 201
 
     @request_view_args
     @request_extra_args

--- a/invenio_communities/members/services/request.py
+++ b/invenio_communities/members/services/request.py
@@ -124,3 +124,21 @@ class CommunityInvitation(RequestType):
             "manager",
         ]
     }
+
+
+class MembershipRequestRequestType(RequestType):
+    """Request type for membership requests."""
+
+    type_id = "community-membership-request"
+    name = _("Membership request")
+
+    create_action = "create"
+    available_actions = {
+        "create": actions.CreateAndSubmitAction,
+    }
+
+    creator_can_be_none = False
+    topic_can_be_none = False
+    allowed_creator_ref_types = ["user"]
+    allowed_receiver_ref_types = ["community"]
+    allowed_topic_ref_types = ["community"]

--- a/invenio_communities/members/services/request.py
+++ b/invenio_communities/members/services/request.py
@@ -30,6 +30,11 @@ def service():
 
 
 #
+# CommunityInvitation: actions and request type
+#
+
+
+#
 # Actions
 #
 # All actions use `system_identity` and not the `identity` param, because
@@ -126,6 +131,21 @@ class CommunityInvitation(RequestType):
     }
 
 
+#
+# MembershipRequestRequestType: actions and request type
+#
+
+
+class CancelMembershipRequestAction(actions.CancelAction):
+    """Cancel membership request action."""
+
+    def execute(self, identity, uow):
+        """Execute action."""
+        service().close_membership_request(system_identity, self.request.id, uow=uow)
+        # TODO: Investigate notifications
+        super().execute(identity, uow)
+
+
 class MembershipRequestRequestType(RequestType):
     """Request type for membership requests."""
 
@@ -135,6 +155,7 @@ class MembershipRequestRequestType(RequestType):
     create_action = "create"
     available_actions = {
         "create": actions.CreateAndSubmitAction,
+        "cancel": CancelMembershipRequestAction,
     }
 
     creator_can_be_none = False

--- a/invenio_communities/members/services/schemas.py
+++ b/invenio_communities/members/services/schemas.py
@@ -93,6 +93,12 @@ class DeleteBulkSchema(MembersSchema):
     """Delete bulk schema."""
 
 
+class RequestMembershipSchema(Schema):
+    """Schema used for requesting membership."""
+
+    message = SanitizedUnicode()
+
+
 #
 # Schemas used for dumping a single member
 #

--- a/invenio_communities/members/services/service.py
+++ b/invenio_communities/members/services/service.py
@@ -843,7 +843,17 @@ class MemberService(RecordService):
         pass
 
     @unit_of_work()
-    def decline_membership_request(self, identity, request_id, uow=None):
-        """Decline membership request."""
-        # TODO: Implement me
-        pass
+    def close_membership_request(self, identity, request_id, uow=None):
+        """Close membership request.
+
+        Used for cancelling, declining, or expiring a membership request.
+
+        For now we just delete the "fake" member that was created in
+        request_membership. TODO: explore alternatives/ramifications at a
+        later point.
+        """
+        # Permissions are checked on the request action
+        assert identity == system_identity
+        member = self.record_cls.get_member_by_request(request_id)
+        assert member.active is False
+        uow.register(RecordDeleteOp(member, indexer=self.indexer, force=True))

--- a/invenio_communities/permissions.py
+++ b/invenio_communities/permissions.py
@@ -193,12 +193,13 @@ class CommunityPermissionPolicy(BasePermissionPolicy):
                 IfPolicyClosed(
                     "member_policy",
                     then_=[Disable()],
-                    else_=[AuthenticatedButNotCommunityMembers()]
-                )
+                    else_=[AuthenticatedButNotCommunityMembers()],
+                ),
             ],
-            else_=[Disable()]
+            else_=[Disable()],
         ),
     ]
+
 
 def can_perform_action(community, context):
     """Check if the given action is available on the request."""

--- a/invenio_communities/templates/semantic-ui/invenio_communities/details/base.html
+++ b/invenio_communities/templates/semantic-ui/invenio_communities/details/base.html
@@ -9,6 +9,11 @@
 
 {% extends "invenio_communities/base.html" %}
 
+{%- block javascript %}
+{{ super() }}
+{{ webpack['invenio-communities-header.js'] }}
+{%- endblock javascript %}
+
 {%- block page_body %}
   {% set community_menu_active = True %}
   {% include "invenio_communities/details/header.html" %}

--- a/invenio_communities/templates/semantic-ui/invenio_communities/details/header.html
+++ b/invenio_communities/templates/semantic-ui/invenio_communities/details/header.html
@@ -12,8 +12,8 @@
 {%- from "invenio_communities/details/macros/access-status-label.html" import access_status_label -%}
 
 {% macro button_to_request_membership(community) %}
-  {# TODO: replace by permission check when permissions implemented #}
-  {% if config.COMMUNITIES_ALLOW_MEMBERSHIP_REQUESTS %}
+  {% if permissions.can_request_membership %}
+  {# TODO: Add relation_to_community for other flows #}
   <div
     id="request-membership-app"
     data-community='{{ community | tojson }}'

--- a/invenio_communities/templates/semantic-ui/invenio_communities/details/header.html
+++ b/invenio_communities/templates/semantic-ui/invenio_communities/details/header.html
@@ -2,6 +2,7 @@
 
   This file is part of Invenio.
   Copyright (C) 2016-2020 CERN.
+  Copyright (C) 2024 Northwestern University.
 
   Invenio is free software; you can redistribute it and/or modify it
   under the terms of the MIT License; see LICENSE file for more details.
@@ -10,12 +11,25 @@
 {%- from "invenio_theme/macros/truncate.html" import truncate_text %}
 {%- from "invenio_communities/details/macros/access-status-label.html" import access_status_label -%}
 
+{% macro button_to_request_membership(community) %}
+  {# TODO: replace by permission check when permissions implemented #}
+  {% if config.COMMUNITIES_ALLOW_MEMBERSHIP_REQUESTS %}
+  <div
+    id="request-membership-app"
+    data-community='{{ community | tojson }}'
+    class="display-inline-block"
+    >
+  </div>
+  {% endif %}
+{% endmacro %}
+
+
 <div
   class="ui container fluid page-subheader-outer with-submenu rel-pt-2 ml-0-mobile mr-0-mobile">
   <div class="ui container relaxed grid page-subheader mr-0-mobile ml-0-mobile">
     <div class="row pb-0">
       <div
-        class="sixteen wide mobile sixteen wide tablet thirteen wide computer column">
+        class="sixteen wide mobile sixteen wide tablet eleven wide computer column">
         <div
           class="community-header flex align-items-center column-mobile align-items-start-mobile">
           <div class="flex align-items-center">
@@ -105,7 +119,8 @@
         </div>
       </div>
       <div
-        class="sixteen wide mobile sixteen wide tablet three wide computer right aligned middle aligned column">
+        class="sixteen wide mobile sixteen wide tablet five wide computer right aligned middle aligned column">
+        {{ button_to_request_membership(community) }}
         {%- if not community_use_jinja_header %}
           <a href="/uploads/new?community={{ community.slug }}"
              class="ui positive button labeled icon rel-mt-1 theme-secondary">

--- a/invenio_communities/views/communities.py
+++ b/invenio_communities/views/communities.py
@@ -107,6 +107,7 @@ HEADER_PERMISSIONS = {
     "search_requests",
     "members_search_public",
     "moderate",
+    "request_membership",
 }
 
 PRIVATE_PERMISSIONS = HEADER_PERMISSIONS | {

--- a/invenio_communities/views/communities.py
+++ b/invenio_communities/views/communities.py
@@ -82,6 +82,24 @@ REVIEW_POLICY_FIELDS = [
 ]
 
 
+MEMBER_POLICY_FIELDS = [
+    {
+        "text": "Open",
+        "value": "open",
+        "icon": "user plus",
+        "helpText": _("Users can request to join your community."),
+    },
+    {
+        "text": "Closed",
+        "value": "closed",
+        "icon": "user times",
+        "helpText": _(
+            "Users cannot request to join your community. Only invited users can become members of your community."
+        ),
+    },
+]
+
+
 HEADER_PERMISSIONS = {
     "read",
     "update",
@@ -341,6 +359,12 @@ def communities_settings_privileges(pid_value, community, community_ui):
     if not permissions["can_manage_access"]:
         raise PermissionDeniedError()
 
+    member_policy = (
+        MEMBER_POLICY_FIELDS
+        if current_app.config["COMMUNITIES_ALLOW_MEMBERSHIP_REQUESTS"]
+        else {}
+    )
+
     return render_community_theme_template(
         "invenio_communities/details/settings/privileges.html",
         theme=community_ui.get("theme", {}),
@@ -349,6 +373,7 @@ def communities_settings_privileges(pid_value, community, community_ui):
             access=dict(
                 visibility=VISIBILITY_FIELDS,
                 members_visibility=MEMBERS_VISIBILITY_FIELDS,
+                member_policy=member_policy,
             ),
         ),
         permissions=permissions,

--- a/invenio_communities/views/communities.py
+++ b/invenio_communities/views/communities.py
@@ -22,6 +22,7 @@ from jinja2 import TemplateError
 from invenio_communities.proxies import current_communities
 
 from ..communities.resources.ui_schema import TypesSchema
+from ..members.records.api import Member
 from .decorators import pass_community
 from .template_loader import CommunityThemeChoiceJinjaLoader
 

--- a/invenio_communities/webpack.py
+++ b/invenio_communities/webpack.py
@@ -26,6 +26,7 @@ communities = WebpackThemeBundle(
     themes={
         "semantic-ui": dict(
             entry={
+                "invenio-communities-header": "./js/invenio_communities/community/header/index.js",
                 "invenio-communities-new": "./js/invenio_communities/community/new.js",
                 "invenio-communities-privileges": "./js/invenio_communities/settings/privileges/index.js",
                 "invenio-communities-profile": "./js/invenio_communities/settings/profile/index.js",

--- a/setup.cfg
+++ b/setup.cfg
@@ -82,6 +82,7 @@ invenio_requests.entity_resolvers =
 invenio_requests.types =
     community_invitation = invenio_communities.members.services.request:CommunityInvitation
     subcommunity = invenio_communities.subcommunities.services.request:subcommunity_request_type
+    membership_request_request_type = invenio_communities.members.services.request:MembershipRequestRequestType
 invenio_i18n.translations =
     messages = invenio_communities
 invenio_administration.views =
@@ -95,8 +96,6 @@ invenio_base.finalize_app =
     invenio_communities = invenio_communities.ext:finalize_app
 invenio_base.api_finalize_app =
     invenio_communities = invenio_communities.ext:api_finalize_app
-
-
 
 [build_sphinx]
 source-dir = docs/

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ python_requires = >=3.8
 zip_safe = False
 install_requires =
     invenio-oaiserver>=2.2.0,<3.0.0
-    invenio-requests>=4.0.0,<5.0.0
+    invenio-requests>=4.2.0,<5.0.0
     invenio-search-ui>=2.4.0,<3.0.0
     invenio-vocabularies>=4.0.0,<5.0.0
     invenio-administration>=2.0.0,<3.0.0

--- a/tests/communities/test_permissions.py
+++ b/tests/communities/test_permissions.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2024 Northwestern University.
+#
+# Invenio-RDM-Records is free software; you can redistribute it
+# and/or modify it under the terms of the MIT License; see LICENSE file for
+# more details.
+
+"""Test permissions."""
+
+from invenio_communities.permissions import CommunityPermissionPolicy
+
+
+def test_can_request_membership(
+    app, community, owner, anon_identity, any_user, superuser_identity
+):
+
+    policy = CommunityPermissionPolicy
+    community_record = community._record
+    authenticated_identity = any_user.identity
+
+    allow_membership_requests_orig = app.config["COMMUNITIES_ALLOW_MEMBERSHIP_REQUESTS"]
+
+    # Case - feature disabled
+    app.config["COMMUNITIES_ALLOW_MEMBERSHIP_REQUESTS"] = False
+    assert not (
+        policy(action="request_membership", record=community_record).allows(
+            superuser_identity
+        )
+    )
+
+    app.config["COMMUNITIES_ALLOW_MEMBERSHIP_REQUESTS"] = True
+
+    # Case - setting disabled
+    community_record.access.member_policy = "closed"
+    assert not (
+        policy(action="request_membership", record=community_record).allows(
+            superuser_identity
+        )
+    )
+
+    community_record.access.member_policy = "open"
+
+    # Case - unlogged user
+    assert not (
+        policy(action="request_membership", record=community_record).allows(
+            anon_identity
+        )
+    )
+
+    # Case - logged user not part of community
+    assert policy(action="request_membership", record=community_record).allows(
+        authenticated_identity
+    )
+
+    # Case - member of community
+    assert not (
+        policy(action="request_membership", record=community_record).allows(
+            owner.identity
+        )
+    )
+
+    app.config["COMMUNITIES_ALLOW_MEMBERSHIP_REQUESTS"] = allow_membership_requests_orig

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -371,7 +371,7 @@ def create_user(UserFixture, app, db):
     is essential for many tests.
     """
 
-    def _create_user(data):
+    def _create_user(data=None):
         """Create user."""
         default_data = dict(
             email="user@example.org",
@@ -391,6 +391,7 @@ def create_user(UserFixture, app, db):
             active=True,
             confirmed=True,
         )
+        data = data or {}
         actual_data = dict(default_data, **data)
         u = UserFixture(**actual_data)
         u.create(app, db)

--- a/tests/members/conftest.py
+++ b/tests/members/conftest.py
@@ -16,6 +16,7 @@ import pytest
 from invenio_access.permissions import system_identity
 from invenio_requests.records.api import Request
 from invenio_search import current_search
+from invenio_users_resources.proxies import current_users_service
 
 from invenio_communities.members.records.api import ArchivedInvitation, Member
 
@@ -93,3 +94,17 @@ def invite_request_id(requests_service, invite_user):
         type="community-invitation",
     ).to_dict()
     return res["hits"]["hits"][0]["id"]
+
+
+@pytest.fixture(scope="function")
+def membership_request(member_service, community, create_user, db, search_clear):
+    """A membership request."""
+    user = create_user()
+    data = {
+        "message": "Can I join the club?",
+    }
+    return member_service.request_membership(
+        user.identity,
+        community._record.id,
+        data,
+    )

--- a/tests/members/test_members_notifications.py
+++ b/tests/members/test_members_notifications.py
@@ -1,0 +1,338 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2024 Northwestern University.
+# Copyright (C) 2022-2023 Graz University of Technology.
+#
+# Invenio-Communities is free software; you can redistribute it and/or modify
+# it under the terms of the MIT License; see LICENSE file for more details.
+
+from unittest.mock import MagicMock
+
+from invenio_access.permissions import system_identity
+from invenio_notifications.proxies import current_notifications_manager
+
+from invenio_communities.notifications.builders import (
+    CommunityInvitationAcceptNotificationBuilder,
+    CommunityInvitationCancelNotificationBuilder,
+    CommunityInvitationDeclineNotificationBuilder,
+    CommunityInvitationExpireNotificationBuilder,
+    CommunityInvitationSubmittedNotificationBuilder,
+)
+
+
+#
+# invenio-notification testcases
+#
+def test_community_invitation_submit_notification(
+    member_service,
+    requests_service,
+    community,
+    owner,
+    new_user,
+    db,
+    monkeypatch,
+    app,
+    clean_index,
+):
+    """Test notifcation being built on community invitation submit."""
+
+    original_builder = CommunityInvitationSubmittedNotificationBuilder
+
+    # mock build to observe calls
+    mock_build = MagicMock()
+    mock_build.side_effect = original_builder.build
+    monkeypatch.setattr(original_builder, "build", mock_build)
+    # setting specific builder for test case
+    monkeypatch.setattr(
+        current_notifications_manager,
+        "builders",
+        {
+            **current_notifications_manager.builders,
+            original_builder.type: original_builder,
+        },
+    )
+    assert not mock_build.called
+
+    mail = app.extensions.get("mail")
+    assert mail
+
+    with mail.record_messages() as outbox:
+        # Validate that email was sent
+        role = "reader"
+        message = "<p>invitation message</p>"
+
+        data = {
+            "members": [{"type": "user", "id": str(new_user.id)}],
+            "role": role,
+            "message": message,
+        }
+        member_service.invite(owner.identity, community.id, data)
+        # ensure that the invited user request has been indexed
+        res = member_service.search_invitations(owner.identity, community.id).to_dict()
+        assert res["hits"]["total"] == 1
+        inv = res["hits"]["hits"][0]
+
+        # check notification is build on submit
+        assert mock_build.called
+        assert len(outbox) == 1
+        html = outbox[0].html
+        # TODO: update to `req["links"]["self_html"]` when addressing https://github.com/inveniosoftware/invenio-rdm-records/issues/1327
+        assert "/me/requests/{}".format(inv["request"]["id"]) in html
+        # role titles will be capitalized
+        assert role.capitalize() in html
+        assert "You have been invited to join" in html
+        assert message in html
+        assert community["metadata"]["title"] in html
+
+    # decline to reset
+    requests_service.execute_action(new_user.identity, inv["request"]["id"], "decline")
+    with mail.record_messages() as outbox:
+        data = {
+            "members": [{"type": "user", "id": str(new_user.id)}],
+            "role": role,
+        }
+        # invite again without message
+        member_service.invite(owner.identity, community.id, data)
+        # ensure that the invited user request has been indexed
+        res = member_service.search_invitations(owner.identity, community.id).to_dict()
+        assert res["hits"]["total"] == 2
+        inv = res["hits"]["hits"][1]
+
+        # check notification is build on submit
+        assert mock_build.called
+        assert len(outbox) == 1
+        html = outbox[0].html
+        # TODO: update to `req["links"]["self_html"]` when addressing https://github.com/inveniosoftware/invenio-rdm-records/issues/1327
+        assert "/me/requests/{}".format(inv["request"]["id"]) in html
+        # role titles will be capitalized
+        assert role.capitalize() in html
+        assert "You have been invited to join" in html
+        assert "with the following message:" not in html
+        assert community["metadata"]["title"] in html
+
+
+def test_community_invitation_accept_notification(
+    member_service,
+    requests_service,
+    community,
+    new_user,
+    db,
+    monkeypatch,
+    app,
+    members,
+    clean_index,
+):
+    """Test notifcation sent on community invitation accept."""
+
+    original_builder = CommunityInvitationAcceptNotificationBuilder
+
+    owner = members["owner"]
+    # mock build to observe calls
+    mock_build = MagicMock()
+    mock_build.side_effect = original_builder.build
+    monkeypatch.setattr(original_builder, "build", mock_build)
+    assert not mock_build.called
+
+    mail = app.extensions.get("mail")
+    assert mail
+
+    role = "reader"
+    data = {
+        "members": [{"type": "user", "id": str(new_user.id)}],
+        "role": role,
+    }
+    member_service.invite(owner.identity, community.id, data)
+    res = member_service.search_invitations(owner.identity, community.id).to_dict()
+    assert res["hits"]["total"] == 1
+    inv = res["hits"]["hits"][0]
+    with mail.record_messages() as outbox:
+        # Validate that email was sent
+        requests_service.execute_action(
+            new_user.identity, inv["request"]["id"], "accept"
+        )
+        # check notification is build on submit
+        assert mock_build.called
+        # community owner, manager get notified
+        assert len(outbox) == 2
+        html = outbox[0].html
+        # TODO: update to `req["links"]["self_html"]` when addressing https://github.com/inveniosoftware/invenio-rdm-records/issues/1327
+        assert "/me/requests/{}".format(inv["request"]["id"]) in html
+        # role titles will be capitalized
+        assert (
+            "'@{who}' accepted the invitation to join your community '{title}'".format(
+                who=new_user.user.username
+                or new_user.user.user_profile.get("full_name"),
+                title=community["metadata"]["title"],
+            )
+            in html
+        )
+
+
+def test_community_invitation_cancel_notification(
+    member_service,
+    requests_service,
+    community,
+    owner,
+    new_user,
+    db,
+    monkeypatch,
+    app,
+    clean_index,
+):
+    """Test notifcation sent on community invitation cancel."""
+
+    original_builder = CommunityInvitationCancelNotificationBuilder
+
+    # mock build to observe calls
+    mock_build = MagicMock()
+    mock_build.side_effect = original_builder.build
+    monkeypatch.setattr(original_builder, "build", mock_build)
+    assert not mock_build.called
+
+    mail = app.extensions.get("mail")
+    assert mail
+
+    role = "reader"
+    data = {
+        "members": [{"type": "user", "id": str(new_user.id)}],
+        "role": role,
+    }
+
+    member_service.invite(owner.identity, community.id, data)
+    res = member_service.search_invitations(owner.identity, community.id).to_dict()
+    assert res["hits"]["total"] == 1
+    inv = res["hits"]["hits"][0]
+    with mail.record_messages() as outbox:
+        # Validate that email was sent
+        requests_service.execute_action(owner.identity, inv["request"]["id"], "cancel")
+        # check notification is build on submit
+        assert mock_build.called
+        # invited user gets notified
+        assert len(outbox) == 1
+        html = outbox[0].html
+        # TODO: update to `req["links"]["self_html"]` when addressing https://github.com/inveniosoftware/invenio-rdm-records/issues/1327
+        assert "/me/requests/{}".format(inv["request"]["id"]) in html
+        # role titles will be capitalized
+        assert (
+            "The invitation for '@{who}' to join community '{title}' was cancelled".format(
+                who=new_user.user.username
+                or new_user.user.user_profile.get("full_name"),
+                title=community["metadata"]["title"],
+            )
+            in html
+        )
+
+
+def test_community_invitation_decline_notification(
+    member_service,
+    requests_service,
+    community,
+    new_user,
+    db,
+    monkeypatch,
+    app,
+    members,
+    clean_index,
+):
+    """Test notifcation sent on community invitation decline."""
+
+    owner = members["owner"]
+    original_builder = CommunityInvitationDeclineNotificationBuilder
+
+    # mock build to observe calls
+    mock_build = MagicMock()
+    mock_build.side_effect = original_builder.build
+    monkeypatch.setattr(original_builder, "build", mock_build)
+    assert not mock_build.called
+
+    mail = app.extensions.get("mail")
+    assert mail
+
+    role = "reader"
+    data = {
+        "members": [{"type": "user", "id": str(new_user.id)}],
+        "role": role,
+    }
+    member_service.invite(owner.identity, community.id, data)
+    res = member_service.search_invitations(owner.identity, community.id).to_dict()
+    assert res["hits"]["total"] == 1
+    inv = res["hits"]["hits"][0]
+    with mail.record_messages() as outbox:
+        # Validate that email was sent
+        # Added resp
+        resp = requests_service.execute_action(
+            new_user.identity, inv["request"]["id"], "decline"
+        )
+        # check notification is build on submit
+        assert mock_build.called
+        # community owner, manager get notified
+        assert len(outbox) == 2
+        html = outbox[0].html
+        # TODO: update to `req["links"]["self_html"]` when addressing https://github.com/inveniosoftware/invenio-rdm-records/issues/1327
+        assert "/me/requests/{}".format(inv["request"]["id"]) in html
+        # role titles will be capitalized
+        assert (
+            "'@{who}' declined the invitation to join your community '{title}'".format(
+                who=new_user.user.username
+                or new_user.user.user_profile.get("full_name"),
+                title=community["metadata"]["title"],
+            )
+            in html
+        )
+
+
+def test_community_invitation_expire_notification(
+    member_service,
+    requests_service,
+    community,
+    new_user,
+    db,
+    monkeypatch,
+    app,
+    members,
+    clean_index,
+):
+    """Test notifcation sent on community invitation decline."""
+
+    owner = members["owner"]
+    original_builder = CommunityInvitationExpireNotificationBuilder
+
+    # mock build to observe calls
+    mock_build = MagicMock()
+    mock_build.side_effect = original_builder.build
+    monkeypatch.setattr(original_builder, "build", mock_build)
+    assert not mock_build.called
+
+    mail = app.extensions.get("mail")
+    assert mail
+
+    role = "reader"
+    data = {
+        "members": [{"type": "user", "id": str(new_user.id)}],
+        "role": role,
+    }
+    member_service.invite(owner.identity, community.id, data)
+    res = member_service.search_invitations(owner.identity, community.id).to_dict()
+    assert res["hits"]["total"] == 1
+    inv = res["hits"]["hits"][0]
+    with mail.record_messages() as outbox:
+        # Validate that email was sent
+        requests_service.execute_action(system_identity, inv["request"]["id"], "expire")
+
+        # check notification is build on submit
+        assert mock_build.called
+        # community owner, manager and invited user get notified
+        # TODO: Replace with equivalent
+        assert len(outbox) == 3
+        html = outbox[0].html
+        # TODO: update to `req["links"]["self_html"]` when addressing https://github.com/inveniosoftware/invenio-rdm-records/issues/1327
+        assert "/me/requests/{}".format(inv["request"]["id"]) in html
+        # role titles will be capitalized
+        assert (
+            "The invitation for '@{who}' to join community '{title}' has expired.".format(
+                who=new_user.user.username
+                or new_user.user.user_profile.get("full_name"),
+                title=community["metadata"]["title"],
+            )
+            in html
+        )

--- a/tests/members/test_members_resource.py
+++ b/tests/members/test_members_resource.py
@@ -11,6 +11,7 @@
 import pytest
 from invenio_access.permissions import system_identity
 from invenio_requests.records.api import RequestEvent
+from invenio_users_resources.proxies import current_users_service
 
 
 #
@@ -134,7 +135,7 @@ def test_invite_deny(client, headers, community_id, new_user, new_user_data, db)
 #
 # Update
 #
-def test_update(client, headers, community_id, owner, public_reader):
+def test_update(client, headers, community_id, owner, public_reader, db):
     """Test update of members."""
     client = owner.login(client)
     data = {
@@ -357,3 +358,73 @@ def test_search_invitation(
 # TODO: facet by role, facet by visibility, define sorts.
 # TODO: same user can be invited to two different communities
 # TODO: same user/group can be added to two different communities
+
+
+#
+# Membership request
+#
+
+
+def test_post_membership_requests(app, client, headers, community_id, create_user, db):
+    user = create_user({"email": "user_foo@example.org", "username": "user_foo"})
+    client = user.login(client)
+
+    # Post membership request
+    r = client.post(
+        f"/communities/{community_id}/membership-requests",
+        headers=headers,
+        json={"message": "Can I join the club?"},
+    )
+    assert 201 == r.status_code
+
+    RequestEvent.index.refresh()
+
+    # Get links to check
+    url_of_request = r.json["links"]["self"].replace(app.config["SITE_API_URL"], "")
+    url_of_timeline = r.json["links"]["timeline"].replace(
+        app.config["SITE_API_URL"],
+        "",
+    )
+
+    # Check the request
+    r = client.get(url_of_request, headers=headers)
+    assert 200 == r.status_code
+    assert 'Request to join "My Community"' in r.json["title"]
+
+    # Check the timeline
+    r = client.get(url_of_timeline, headers=headers)
+    assert 200 == r.status_code
+    assert 1 == r.json["hits"]["total"]
+    msg = r.json["hits"]["hits"][0]["payload"]["content"]
+    assert "Can I join the club?" == msg
+
+
+def test_put_membership_requests(
+    client, headers, community_id, owner, new_user_data, db
+):
+    # update membership request
+    # TODO: Implement me!
+    assert True
+
+
+def test_error_handling_for_membership_requests(
+    client, headers, community_id, owner, new_user_data, db
+):
+    # TODO: Implement me!
+    # error handling registered
+    #   - permission handling registered
+    #   - duplicate handling registered
+    assert True
+
+
+# Is cancelling request purview of this?
+
+
+# TODO: search membership requests
+def test_get_membership_requests(client):
+    # TODO: Implement me!
+    assert True
+    #     RequestEvent.index.refresh()
+    #     r = client.get(f"/communities/{community_id}/membership-requests", headers=headers)
+    #     assert r.status_code == 200
+    #     request_id = r.json["hits"]["hits"][0]["request"]["id"]

--- a/tests/members/test_members_resource.py
+++ b/tests/members/test_members_resource.py
@@ -417,14 +417,7 @@ def test_error_handling_for_membership_requests(
     assert True
 
 
-# Is cancelling request purview of this?
-
-
 # TODO: search membership requests
 def test_get_membership_requests(client):
     # TODO: Implement me!
     assert True
-    #     RequestEvent.index.refresh()
-    #     r = client.get(f"/communities/{community_id}/membership-requests", headers=headers)
-    #     assert r.status_code == 200
-    #     request_id = r.json["hits"]["hits"][0]["request"]["id"]

--- a/tests/members/test_members_services.py
+++ b/tests/members/test_members_services.py
@@ -1166,6 +1166,49 @@ def test_update_invalid_data(member_service, community, group):
 
 
 #
+# Membership requests
+# Just a few choice tests given it's similar to other requests, and permissions have
+# been tested elsewhere.
+#
+
+
+def test_request_cancel_request_flow(
+    member_service,
+    community,
+    create_user,
+    requests_service,
+    db,
+    search_clear,
+):
+    """Check creation of membership request after first creation closed.
+
+    This tests a temporary business rule that should be revisited later.
+    """
+    # Create membership request
+    user = create_user()
+    data = {
+        "message": "Can I join the club?",
+    }
+    membership_request = member_service.request_membership(
+        user.identity,
+        community._record.id,
+        data,
+    )
+
+    # Close request - here via cancel
+    request = requests_service.execute_action(
+        user.identity, membership_request.id, "cancel"
+    ).to_dict()
+
+    # Should be possible to create a new one again
+    membership_request_2 = member_service.request_membership(
+        user.identity,
+        community._record.id,
+        {"message": "Oops didn't mean to cancel. Oh well, I will request again."},
+    )
+
+
+#
 # Change notifications
 #
 def test_relation_update_propagation(
@@ -1193,310 +1236,3 @@ def test_relation_update_propagation(
 
     member = list(comm_members.hits)[0]
     assert member.get("member").get("name") == "Update test"
-
-
-#
-# invenio-notification testcases
-#
-def test_community_invitation_submit_notification(
-    member_service, requests_service, community, owner, new_user, db, monkeypatch, app
-):
-    """Test notifcation being built on community invitation submit."""
-
-    original_builder = CommunityInvitationSubmittedNotificationBuilder
-
-    # mock build to observe calls
-    mock_build = MagicMock()
-    mock_build.side_effect = original_builder.build
-    monkeypatch.setattr(original_builder, "build", mock_build)
-    # setting specific builder for test case
-    monkeypatch.setattr(
-        current_notifications_manager,
-        "builders",
-        {
-            **current_notifications_manager.builders,
-            original_builder.type: original_builder,
-        },
-    )
-    assert not mock_build.called
-
-    mail = app.extensions.get("mail")
-    assert mail
-
-    with mail.record_messages() as outbox:
-        # Validate that email was sent
-        role = "reader"
-        message = "<p>invitation message</p>"
-
-        data = {
-            "members": [{"type": "user", "id": str(new_user.id)}],
-            "role": role,
-            "message": message,
-        }
-        member_service.invite(owner.identity, community.id, data)
-        # ensure that the invited user request has been indexed
-        res = member_service.search_invitations(owner.identity, community.id).to_dict()
-        assert res["hits"]["total"] == 1
-        inv = res["hits"]["hits"][0]
-
-        # check notification is build on submit
-        assert mock_build.called
-        assert len(outbox) == 1
-        html = outbox[0].html
-        # TODO: update to `req["links"]["self_html"]` when addressing https://github.com/inveniosoftware/invenio-rdm-records/issues/1327
-        assert "/me/requests/{}".format(inv["request"]["id"]) in html
-        # role titles will be capitalized
-        assert role.capitalize() in html
-        assert "You have been invited to join" in html
-        assert message in html
-        assert community["metadata"]["title"] in html
-
-    # decline to reset
-    requests_service.execute_action(new_user.identity, inv["request"]["id"], "decline")
-    with mail.record_messages() as outbox:
-        data = {
-            "members": [{"type": "user", "id": str(new_user.id)}],
-            "role": role,
-        }
-        # invite again without message
-        member_service.invite(owner.identity, community.id, data)
-        # ensure that the invited user request has been indexed
-        res = member_service.search_invitations(owner.identity, community.id).to_dict()
-        assert res["hits"]["total"] == 2
-        inv = res["hits"]["hits"][1]
-
-        # check notification is build on submit
-        assert mock_build.called
-        assert len(outbox) == 1
-        html = outbox[0].html
-        # TODO: update to `req["links"]["self_html"]` when addressing https://github.com/inveniosoftware/invenio-rdm-records/issues/1327
-        assert "/me/requests/{}".format(inv["request"]["id"]) in html
-        # role titles will be capitalized
-        assert role.capitalize() in html
-        assert "You have been invited to join" in html
-        assert "with the following message:" not in html
-        assert community["metadata"]["title"] in html
-
-
-def test_community_invitation_accept_notification(
-    member_service,
-    requests_service,
-    community,
-    new_user,
-    db,
-    monkeypatch,
-    app,
-    members,
-    clean_index,
-):
-    """Test notifcation sent on community invitation accept."""
-
-    original_builder = CommunityInvitationAcceptNotificationBuilder
-
-    owner = members["owner"]
-    # mock build to observe calls
-    mock_build = MagicMock()
-    mock_build.side_effect = original_builder.build
-    monkeypatch.setattr(original_builder, "build", mock_build)
-    assert not mock_build.called
-
-    mail = app.extensions.get("mail")
-    assert mail
-
-    role = "reader"
-    data = {
-        "members": [{"type": "user", "id": str(new_user.id)}],
-        "role": role,
-    }
-    member_service.invite(owner.identity, community.id, data)
-    res = member_service.search_invitations(owner.identity, community.id).to_dict()
-    assert res["hits"]["total"] == 1
-    inv = res["hits"]["hits"][0]
-    with mail.record_messages() as outbox:
-        # Validate that email was sent
-        requests_service.execute_action(
-            new_user.identity, inv["request"]["id"], "accept"
-        )
-        # check notification is build on submit
-        assert mock_build.called
-        # community owner, manager get notified
-        assert len(outbox) == 2
-        html = outbox[0].html
-        # TODO: update to `req["links"]["self_html"]` when addressing https://github.com/inveniosoftware/invenio-rdm-records/issues/1327
-        assert "/me/requests/{}".format(inv["request"]["id"]) in html
-        # role titles will be capitalized
-        assert (
-            "'@{who}' accepted the invitation to join your community '{title}'".format(
-                who=new_user.user.username
-                or new_user.user.user_profile.get("full_name"),
-                title=community["metadata"]["title"],
-            )
-            in html
-        )
-
-
-def test_community_invitation_cancel_notification(
-    member_service,
-    requests_service,
-    community,
-    owner,
-    new_user,
-    db,
-    monkeypatch,
-    app,
-    clean_index,
-):
-    """Test notifcation sent on community invitation cancel."""
-
-    original_builder = CommunityInvitationCancelNotificationBuilder
-
-    # mock build to observe calls
-    mock_build = MagicMock()
-    mock_build.side_effect = original_builder.build
-    monkeypatch.setattr(original_builder, "build", mock_build)
-    assert not mock_build.called
-
-    mail = app.extensions.get("mail")
-    assert mail
-
-    role = "reader"
-    data = {
-        "members": [{"type": "user", "id": str(new_user.id)}],
-        "role": role,
-    }
-
-    member_service.invite(owner.identity, community.id, data)
-    res = member_service.search_invitations(owner.identity, community.id).to_dict()
-    assert res["hits"]["total"] == 1
-    inv = res["hits"]["hits"][0]
-    with mail.record_messages() as outbox:
-        # Validate that email was sent
-        requests_service.execute_action(owner.identity, inv["request"]["id"], "cancel")
-        # check notification is build on submit
-        assert mock_build.called
-        # invited user gets notified
-        assert len(outbox) == 1
-        html = outbox[0].html
-        # TODO: update to `req["links"]["self_html"]` when addressing https://github.com/inveniosoftware/invenio-rdm-records/issues/1327
-        assert "/me/requests/{}".format(inv["request"]["id"]) in html
-        # role titles will be capitalized
-        assert (
-            "The invitation for '@{who}' to join community '{title}' was cancelled".format(
-                who=new_user.user.username
-                or new_user.user.user_profile.get("full_name"),
-                title=community["metadata"]["title"],
-            )
-            in html
-        )
-
-
-def test_community_invitation_decline_notification(
-    member_service,
-    requests_service,
-    community,
-    new_user,
-    db,
-    monkeypatch,
-    app,
-    members,
-    clean_index,
-):
-    """Test notifcation sent on community invitation decline."""
-
-    owner = members["owner"]
-    original_builder = CommunityInvitationDeclineNotificationBuilder
-
-    # mock build to observe calls
-    mock_build = MagicMock()
-    mock_build.side_effect = original_builder.build
-    monkeypatch.setattr(original_builder, "build", mock_build)
-    assert not mock_build.called
-
-    mail = app.extensions.get("mail")
-    assert mail
-
-    role = "reader"
-    data = {
-        "members": [{"type": "user", "id": str(new_user.id)}],
-        "role": role,
-    }
-    member_service.invite(owner.identity, community.id, data)
-    res = member_service.search_invitations(owner.identity, community.id).to_dict()
-    assert res["hits"]["total"] == 1
-    inv = res["hits"]["hits"][0]
-    with mail.record_messages() as outbox:
-        # Validate that email was sent
-        requests_service.execute_action(
-            new_user.identity, inv["request"]["id"], "decline"
-        )
-        # check notification is build on submit
-        assert mock_build.called
-        # community owner, manager get notified
-        assert len(outbox) == 2
-        html = outbox[0].html
-        # TODO: update to `req["links"]["self_html"]` when addressing https://github.com/inveniosoftware/invenio-rdm-records/issues/1327
-        assert "/me/requests/{}".format(inv["request"]["id"]) in html
-        # role titles will be capitalized
-        assert (
-            "'@{who}' declined the invitation to join your community '{title}'".format(
-                who=new_user.user.username
-                or new_user.user.user_profile.get("full_name"),
-                title=community["metadata"]["title"],
-            )
-            in html
-        )
-
-
-def test_community_invitation_expire_notification(
-    member_service,
-    requests_service,
-    community,
-    new_user,
-    db,
-    monkeypatch,
-    app,
-    members,
-    clean_index,
-):
-    """Test notifcation sent on community invitation decline."""
-
-    owner = members["owner"]
-    original_builder = CommunityInvitationExpireNotificationBuilder
-
-    # mock build to observe calls
-    mock_build = MagicMock()
-    mock_build.side_effect = original_builder.build
-    monkeypatch.setattr(original_builder, "build", mock_build)
-    assert not mock_build.called
-
-    mail = app.extensions.get("mail")
-    assert mail
-
-    role = "reader"
-    data = {
-        "members": [{"type": "user", "id": str(new_user.id)}],
-        "role": role,
-    }
-    member_service.invite(owner.identity, community.id, data)
-    res = member_service.search_invitations(owner.identity, community.id).to_dict()
-    assert res["hits"]["total"] == 1
-    inv = res["hits"]["hits"][0]
-    with mail.record_messages() as outbox:
-        # Validate that email was sent
-        requests_service.execute_action(system_identity, inv["request"]["id"], "expire")
-        # check notification is build on submit
-        assert mock_build.called
-        # community owner, manager and invited user get notified
-        assert len(outbox) == 3
-        html = outbox[0].html
-        # TODO: update to `req["links"]["self_html"]` when addressing https://github.com/inveniosoftware/invenio-rdm-records/issues/1327
-        assert "/me/requests/{}".format(inv["request"]["id"]) in html
-        # role titles will be capitalized
-        assert (
-            "The invitation for '@{who}' to join community '{title}' has expired.".format(
-                who=new_user.user.username
-                or new_user.user.user_profile.get("full_name"),
-                title=community["metadata"]["title"],
-            )
-            in html
-        )


### PR DESCRIPTION
**This one**
- js+service: [#855] 4) integrate request flow with frontend [+]

This concludes the 2nd flow of the membership request feature.
Remaining flows are
- 'waiting for decision' flow
- 'making a decision' flow

This PR depends on: https://github.com/inveniosoftware/invenio-requests/pull/382 (well not directly but for full effect)


*Screencast*

[Screencast from 05-07-2024 02:16:56 PM.webm](https://github.com/inveniosoftware/invenio-communities/assets/1932651/1d9f1ab5-8115-47ef-a05f-d42357797add)

(Note: "Deleted User" is something I get locally even without any of my code changes from this and previous PRs. As such putting that aside)

**Previous ones**
- settings-ui: [#855] set membership policy
- header-ui: [#855] add inert request membership button+modal
- permissions: add can_request_membership
- resources: [#855] add POST request_membership
