### PR TITLE
release: v2.8.11

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,8 +9,12 @@
 Changes
 =======
 
+Version 2.8.11 (released 2024-06-11)
+------------------------------------
+- fix release changes to publish in PyPI
+
 Version 2.8.10 (released 2024-06-10)
------------------------------------
+------------------------------------
 - ui: fix html rendering
 
 Version 2.8.8 (released 2022-07-12)

--- a/invenio_communities/__init__.py
+++ b/invenio_communities/__init__.py
@@ -11,6 +11,6 @@
 from .ext import InvenioCommunities
 from .proxies import current_communities
 
-__version__ = "2.8.10"
+__version__ = "2.8.11"
 
 __all__ = ("InvenioCommunities", "current_communities")


### PR DESCRIPTION
- Fix changes.rst file 
- Release a new version
- Removed tag `v2.8.10` from upstream