### PR TITLE
Invitations & members: Add dynamic mappings for user profiles and preferences

### DIFF
--- a/invenio_communities/members/records/mappings/os-v1/communitymembers/archivedinvitations/archivedinvitation-v1.0.0.json
+++ b/invenio_communities/members/records/mappings/os-v1/communitymembers/archivedinvitations/archivedinvitation-v1.0.0.json
@@ -1,6 +1,24 @@
 {
   "mappings": {
     "dynamic": "strict",
+    "dynamic_templates": [
+      {
+        "user_profile": {
+          "path_match": "user.profile.*",
+          "mapping": {
+            "type": "keyword"
+          }
+        }
+      },
+      {
+        "user_preferences": {
+          "path_match": "user.preferences.*",
+          "mapping": {
+            "type": "keyword"
+          }
+        }
+      }
+    ],
     "properties": {
       "created": {
         "type": "date"
@@ -62,7 +80,8 @@
               "affiliations": {
                 "type": "text"
               }
-            }
+            },
+            "dynamic": true
           },
           "preferences": {
             "properties": {
@@ -87,7 +106,8 @@
                   }
                 }
               }
-            }
+            },
+            "dynamic": true
           }
         }
       },

--- a/invenio_communities/members/records/mappings/os-v1/communitymembers/members/member-v1.0.0.json
+++ b/invenio_communities/members/records/mappings/os-v1/communitymembers/members/member-v1.0.0.json
@@ -1,6 +1,24 @@
 {
   "mappings": {
     "dynamic": "strict",
+    "dynamic_templates": [
+      {
+        "user_profile": {
+          "path_match": "user.profile.*",
+          "mapping": {
+            "type": "keyword"
+          }
+        }
+      },
+      {
+        "user_preferences": {
+          "path_match": "user.preferences.*",
+          "mapping": {
+            "type": "keyword"
+          }
+        }
+      }
+    ],
     "properties": {
       "created": {
         "type": "date"
@@ -62,7 +80,8 @@
               "affiliations": {
                 "type": "text"
               }
-            }
+            },
+            "dynamic": true
           },
           "preferences": {
             "properties": {
@@ -87,7 +106,8 @@
                   }
                 }
               }
-            }
+            },
+            "dynamic": true
           }
         }
       },

--- a/invenio_communities/members/records/mappings/os-v2/communitymembers/archivedinvitations/archivedinvitation-v1.0.0.json
+++ b/invenio_communities/members/records/mappings/os-v2/communitymembers/archivedinvitations/archivedinvitation-v1.0.0.json
@@ -1,6 +1,24 @@
 {
   "mappings": {
     "dynamic": "strict",
+    "dynamic_templates": [
+      {
+        "user_profile": {
+          "path_match": "user.profile.*",
+          "mapping": {
+            "type": "keyword"
+          }
+        }
+      },
+      {
+        "user_preferences": {
+          "path_match": "user.preferences.*",
+          "mapping": {
+            "type": "keyword"
+          }
+        }
+      }
+    ],
     "properties": {
       "created": {
         "type": "date"
@@ -62,7 +80,8 @@
               "affiliations": {
                 "type": "text"
               }
-            }
+            },
+            "dynamic": true
           },
           "preferences": {
             "properties": {
@@ -87,7 +106,8 @@
                   }
                 }
               }
-            }
+            },
+            "dynamic": true
           }
         }
       },

--- a/invenio_communities/members/records/mappings/os-v2/communitymembers/members/member-v1.0.0.json
+++ b/invenio_communities/members/records/mappings/os-v2/communitymembers/members/member-v1.0.0.json
@@ -1,6 +1,24 @@
 {
   "mappings": {
     "dynamic": "strict",
+    "dynamic_templates": [
+      {
+        "user_profile": {
+          "path_match": "user.profile.*",
+          "mapping": {
+            "type": "keyword"
+          }
+        }
+      },
+      {
+        "user_preferences": {
+          "path_match": "user.preferences.*",
+          "mapping": {
+            "type": "keyword"
+          }
+        }
+      }
+    ],
     "properties": {
       "created": {
         "type": "date"
@@ -62,7 +80,8 @@
               "affiliations": {
                 "type": "text"
               }
-            }
+            },
+            "dynamic": true
           },
           "preferences": {
             "properties": {
@@ -87,7 +106,8 @@
                   }
                 }
               }
-            }
+            },
+            "dynamic": true
           }
         }
       },

--- a/invenio_communities/members/records/mappings/v7/communitymembers/archivedinvitations/archivedinvitation-v1.0.0.json
+++ b/invenio_communities/members/records/mappings/v7/communitymembers/archivedinvitations/archivedinvitation-v1.0.0.json
@@ -1,6 +1,24 @@
 {
   "mappings": {
     "dynamic": "strict",
+    "dynamic_templates": [
+      {
+        "user_profile": {
+          "path_match": "user.profile.*",
+          "mapping": {
+            "type": "keyword"
+          }
+        }
+      },
+      {
+        "user_preferences": {
+          "path_match": "user.preferences.*",
+          "mapping": {
+            "type": "keyword"
+          }
+        }
+      }
+    ],
     "properties": {
       "created": {
         "type": "date"
@@ -62,7 +80,8 @@
               "affiliations": {
                 "type": "text"
               }
-            }
+            },
+            "dynamic": true
           },
           "preferences": {
             "properties": {
@@ -87,7 +106,8 @@
                   }
                 }
               }
-            }
+            },
+            "dynamic": true
           }
         }
       },

--- a/invenio_communities/members/records/mappings/v7/communitymembers/members/member-v1.0.0.json
+++ b/invenio_communities/members/records/mappings/v7/communitymembers/members/member-v1.0.0.json
@@ -1,6 +1,24 @@
 {
   "mappings": {
     "dynamic": "strict",
+    "dynamic_templates": [
+      {
+        "user_profile": {
+          "path_match": "user.profile.*",
+          "mapping": {
+            "type": "keyword"
+          }
+        }
+      },
+      {
+        "user_preferences": {
+          "path_match": "user.preferences.*",
+          "mapping": {
+            "type": "keyword"
+          }
+        }
+      }
+    ],
     "properties": {
       "created": {
         "type": "date"
@@ -62,7 +80,8 @@
               "affiliations": {
                 "type": "text"
               }
-            }
+            },
+            "dynamic": true
           },
           "preferences": {
             "properties": {
@@ -87,7 +106,8 @@
                   }
                 }
               }
-            }
+            },
+            "dynamic": true
           }
         }
       },


### PR DESCRIPTION
The user profiles and preferences offer a mechanism to add custom fields, but the community members & invitations cannot handle anything unexpected.
This PR fixes that by adding the same `dynamic{,_templates}` settings present in the [users mappings](https://github.com/inveniosoftware/invenio-users-resources/blob/master/invenio_users_resources/records/mappings/os-v2/users/user-v2.0.0.json).