### PR TITLE
subcommunity: updated error mapping in the ui

### DIFF
--- a/invenio_communities/assets/semantic-ui/js/invenio_communities/subcommunity/new.js
+++ b/invenio_communities/assets/semantic-ui/js/invenio_communities/subcommunity/new.js
@@ -35,7 +35,7 @@ const IdentifierField = ({ formConfig }) => {
         "This is your community's unique identifier. You will be able to access your community through the URL:"
       )}
       <br />
-      {`${formConfig.SITE_UI_URL}/communities/${values["community"]["slug"]}`}
+      {`${formConfig.SITE_UI_URL}/communities/${values["metadata"]["slug"]}`}
     </>
   );
 
@@ -139,11 +139,18 @@ class CommunityCreateForm extends Component {
       const { errors, message } = communityErrorSerializer(error);
 
       if (message) {
-        this.setGlobalError(message);
+        this.setGlobalError("The form contains errors or missing fields. Please verify before submitting");
       }
 
       if (errors) {
-        errors.map(({ field, messages }) => setFieldError(field, messages[0]));
+        errors.map(({ field, messages }) => {
+          // Check if the field is already prefixed with "metadata"
+          if (!field.startsWith("metadata")) {
+            // Add "metadata" prefix if not already present
+            field = `metadata.${field.split('.').pop()}`;
+          }
+          setFieldError(field, messages[0]);
+        });
       }
     }
   };


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

Closes Issue https://github.com/zenodo/zenodo-rdm/issues/898



### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
