### PR TITLE
Fix community permission check

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,7 +9,12 @@
 Changes
 =======
 
+Version v15.0.1 (released 2024-08-28)
+
+- fix community permission check
+
 Version v15.0.0 (released 2024-08-26)
+
 - improve communities mapping with edge_ngram analyzer and accent analyzer
 
 Version v14.10.0 (released 2024-08-26)

--- a/invenio_communities/__init__.py
+++ b/invenio_communities/__init__.py
@@ -11,6 +11,6 @@
 from .ext import InvenioCommunities
 from .proxies import current_communities
 
-__version__ = "15.0.0"
+__version__ = "15.0.1"
 
 __all__ = ("InvenioCommunities", "current_communities")

--- a/invenio_communities/communities/resources/ui_schema.py
+++ b/invenio_communities/communities/resources/ui_schema.py
@@ -36,6 +36,9 @@ def _community_permission_check(action, community, identity):
             "community_id",
             community["processed"][0]["community_id"],
         )
+        community = current_communities.service.read(
+            id_=community_id, identity=identity
+        ).to_dict()
 
     return current_communities.service.config.permission_policy_cls(
         action,


### PR DESCRIPTION
Fixes 

```
    return f(self, *args, **kwargs)                                                                                                                                                                                   
  File "/Users/jaromero/.pyenv/versions/3.9.19/envs/cdsrdmupgrade/lib/python3.9/site-packages/flask_resources/responses.py", line 40, in inner                                                                        
    return resource_requestctx.response_handler.make_response(*res, many=many)                                                                                                                                        
  File "/Users/jaromero/.pyenv/versions/3.9.19/envs/cdsrdmupgrade/lib/python3.9/site-packages/flask_resources/responses.py", line 94, in make_response
    "" if obj_or_list is None else serialize(obj_or_list),
  File "/Users/jaromero/.pyenv/versions/3.9.19/envs/cdsrdmupgrade/lib/python3.9/site-packages/flask_resources/serializers/base.py", line 77, in serialize_object
    return self.format_serializer.serialize_object(self.dump_obj(obj))
  File "/Users/jaromero/.pyenv/versions/3.9.19/envs/cdsrdmupgrade/lib/python3.9/site-packages/flask_resources/serializers/base.py", line 66, in dump_obj
    return self.object_schema.dump(obj)
  File "/Users/jaromero/.pyenv/versions/3.9.19/envs/cdsrdmupgrade/lib/python3.9/site-packages/flask_resources/parsers/schema.py", line 95, in dump
    obj[object_key] = Schema.dump(self, obj, **kwargs)
  File "/Users/jaromero/.pyenv/versions/3.9.19/envs/cdsrdmupgrade/lib/python3.9/site-packages/marshmallow/schema.py", line 553, in dump
    result = self._serialize(processed_obj, many=many)
  File "/Users/jaromero/.pyenv/versions/3.9.19/envs/cdsrdmupgrade/lib/python3.9/site-packages/marshmallow/schema.py", line 521, in _serialize
    value = field_obj.serialize(attr_name, obj, accessor=self.get_attribute)
  File "/Users/jaromero/.pyenv/versions/3.9.19/envs/cdsrdmupgrade/lib/python3.9/site-packages/marshmallow/fields.py", line 341, in serialize
    return self._serialize(value, attr, obj, **kwargs)
  File "/Users/jaromero/.pyenv/versions/3.9.19/envs/cdsrdmupgrade/lib/python3.9/site-packages/marshmallow/fields.py", line 1985, in _serialize
    return self._serialize_method(obj)
  File "/Users/jaromero/Cern/invenio/modules/invenio-communities/invenio_communities/communities/resources/ui_schema.py", line 119, in get_permissions
    can_include_directly = _community_permission_check(
  File "/Users/jaromero/Cern/invenio/modules/invenio-communities/invenio_communities/communities/resources/ui_schema.py", line 41, in _community_permission_check
    return current_communities.service.config.permission_policy_cls(
  File "/Users/jaromero/.pyenv/versions/3.9.19/envs/cdsrdmupgrade/lib/python3.9/site-packages/flask_principal.py", line 333, in allows
    if self.needs and not self.needs.intersection(identity.provides):
  File "/Users/jaromero/.pyenv/versions/3.9.19/envs/cdsrdmupgrade/lib/python3.9/site-packages/invenio_records_permissions/policies/base.py", line 86, in needs
    needs = [generator.needs(**self.over) for generator in self.generators]
  File "/Users/jaromero/.pyenv/versions/3.9.19/envs/cdsrdmupgrade/lib/python3.9/site-packages/invenio_records_permissions/policies/base.py", line 86, in <listcomp>
    needs = [generator.needs(**self.over) for generator in self.generators]
  File "/Users/jaromero/Cern/invenio/modules/invenio-communities/invenio_communities/generators.py", line 158, in needs
    g.needs(record=record, **kwargs) for g in self._generators(record, **kwargs)
  File "/Users/jaromero/Cern/invenio/modules/invenio-communities/invenio_communities/generators.py", line 146, in _generators
    review_policy = dict_lookup(record, "access.review_policy")
  File "/Users/jaromero/.pyenv/versions/3.9.19/envs/cdsrdmupgrade/lib/python3.9/site-packages/invenio_records/dictutils.py", line 100, in dict_lookup
    value = value[key]
KeyError: 'access'
```