### PR TITLE
resources: use default response handling for logo update

### DIFF
--- a/invenio_communities/communities/resources/resource.py
+++ b/invenio_communities/communities/resources/resource.py
@@ -126,7 +126,6 @@ class CommunityResource(RecordResource):
 
     @request_view_args
     @request_stream
-    @response_handler()
     def update_logo(self):
         """Upload logo content."""
         item = self.service.update_logo(


### PR DESCRIPTION
* Return raw JSON instead of doing content negotiation for logo update responses.
