### PR TITLE
temp: remove args from self link

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,10 @@
 Changes
 =======
 
+Version v15.2.2 (unreleased)
+
+- subcommunities: temporary fix for self link
+
 Version v15.2.1 (released 2024-10-01)
 
 - subcommunities: fix error getting whether children allowed

--- a/invenio_communities/subcommunities/services/service.py
+++ b/invenio_communities/subcommunities/services/service.py
@@ -75,7 +75,9 @@ class SubCommunityService(Service):
             **kwargs
         )
         self_link = LinksTemplate(
-            pagination_links("{+api}/communities/{community_id}/subcommunities{args}"),
+            # https://github.com/inveniosoftware/invenio-communities/issues/1218
+            # pagination_links("{+api}/communities/{community_id}/subcommunities{?args*}"),
+            pagination_links("{+api}/communities/{community_id}/subcommunities"),
             context={"community_id": id_},
         )
         subcommunities._links_tpl = self_link


### PR DESCRIPTION
Until we are able to get the args properly we should remove them from the self link on the subcommunities endpoint

The remaining issue is shelved here https://github.com/inveniosoftware/invenio-communities/issues/1218 which is noted in the code