### PR TITLE
installation: bump invenio-vocabularies & 📦 release: v16.0.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,10 @@
 Changes
 =======
 
+Version v16.0.0 (released 2024-10-04)
+
+- installation: bump invenio-vocabularies
+
 Version v15.2.2 (released 2024-10-04)
 
 - subcommunities: temporary fix for self link

--- a/invenio_communities/__init__.py
+++ b/invenio_communities/__init__.py
@@ -11,6 +11,6 @@
 from .ext import InvenioCommunities
 from .proxies import current_communities
 
-__version__ = "15.2.2"
+__version__ = "16.0.0"
 
 __all__ = ("InvenioCommunities", "current_communities")

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ install_requires =
     invenio-oaiserver>=2.2.0,<3.0.0
     invenio-requests>=5.0.0,<6.0.0
     invenio-search-ui>=2.4.0,<3.0.0
-    invenio-vocabularies>=5.0.0,<6.0.0
+    invenio-vocabularies>=6.0.0,<7.0.0
     invenio-administration>=2.0.0,<3.0.0
 
 [options.extras_require]


### PR DESCRIPTION
Release fixes inveniosoftware/invenio-vocabularies#401

Bumping `invenio-communities` to a new major version since `invenio-vocabularies` is also being bumped to a major version with breaking changes (see inveniosoftware/invenio-vocabularies#405).