### PR TITLE
subcommunities: revert resource config change

### DIFF
--- a/invenio_communities/subcommunities/resources/config.py
+++ b/invenio_communities/subcommunities/resources/config.py
@@ -55,6 +55,7 @@ class SubCommunityResourceConfig(ConfiguratorMixin, ResourceConfig):
     # Response handling
     response_handlers = {
         "application/json": json_response_handler,
+        "application/vnd.inveniordm.v1+json": json_response_handler,
     }
     default_accept_mimetype = "application/json"
 


### PR DESCRIPTION
The header must be supported for subcommunity requests to work, otherwise the request fails due to unsupported accept header type. 

I am reverting it to the state that was before these [changes](https://github.com/inveniosoftware/invenio-communities/pull/1208/files). 