### PR TITLE
Permissions: Add Community Creator Role for `can_create`

### DIFF
--- a/invenio_communities/config.py
+++ b/invenio_communities/config.py
@@ -2,8 +2,8 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2016-2024 CERN.
-# Copyright (C) 2023 Graz University of Technology.
-# Copyright (C) 2023 KTH Royal Institute of Technology.
+# Copyright (C) 2023      Graz University of Technology.
+# Copyright (C) 2023-2024 KTH Royal Institute of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -334,3 +334,6 @@ COMMUNITIES_ALLOW_MEMBERSHIP_REQUESTS = False
 
 COMMUNITIES_DEFAULT_RECORD_SUBMISSION_POLICY = RecordSubmissionPolicyEnum.OPEN
 """Default value of record submission policy community access setting."""
+
+COMMUNITIES_CREATOR_ROLE = "community-creator"
+"""Depends on 'RDM_COMMUNITY_REQUIRED_TO_PUBLISH' set to True."""

--- a/invenio_communities/generators.py
+++ b/invenio_communities/generators.py
@@ -5,6 +5,7 @@
 # Copyright (C) 2021 Graz University of Technology.
 # Copyright (C) 2021 TU Wien.
 # Copyright (C) 2022 Northwestern University.
+# Copyright (C) 2024 KTH Royal Institute of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -16,7 +17,8 @@ from collections import namedtuple
 from functools import partial, reduce
 from itertools import chain
 
-from flask_principal import UserNeed
+from flask import current_app
+from flask_principal import RoleNeed, UserNeed
 from invenio_access.permissions import any_user, authenticated_user, system_process
 from invenio_records.dictutils import dict_lookup
 from invenio_records_permissions.generators import Generator
@@ -340,6 +342,17 @@ class CommunityManagers(CommunityRoles):
     def roles(self, **kwargs):
         """Roles."""
         return [r.name for r in current_roles.can("manage")]
+
+
+class CommunityCreator(Generator):
+    """Allows users with the "trusted-user" role."""
+
+    def needs(self, **kwargs):
+        """Enabling Needs."""
+        role_name = current_app.config.get(
+            "COMMUNITIES_CREATOR_ROLE", "community-creator"
+        )
+        return [RoleNeed(role_name)]
 
 
 class CommunityManagersForRole(CommunityRoles):

--- a/invenio_communities/permissions.py
+++ b/invenio_communities/permissions.py
@@ -107,11 +107,19 @@ class CommunityPermissionPolicy(BasePermissionPolicy):
     ]
 
     # who can include a record directly, without a review
-    can_include_directly = [
+    _can_include_directly = [
         ReviewPolicy(
             closed_=[Disable()],
             open_=[CommunityCurators()],
             members_=[CommunityMembers()],
+        )
+    ]
+
+    can_include_directly = [
+        IfConfig(
+            "RDM_COMMUNITY_REQUIRED_TO_PUBLISH",
+            then_=[Disable()],
+            else_=_can_include_directly,
         )
     ]
 

--- a/invenio_communities/permissions.py
+++ b/invenio_communities/permissions.py
@@ -5,6 +5,7 @@
 # Copyright (C) 2021 Graz University of Technology.
 # Copyright (C) 2021 TU Wien.
 # Copyright (C) 2022 Northwestern University.
+# Copyright (C) 2024 KTH Royal Institute of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -26,6 +27,7 @@ from invenio_users_resources.services.permissions import UserManager
 from .generators import (
     AllowedMemberTypes,
     AuthenticatedButNotCommunityMembers,
+    CommunityCreator,
     CommunityCurators,
     CommunityManagers,
     CommunityManagersForRole,
@@ -45,7 +47,15 @@ class CommunityPermissionPolicy(BasePermissionPolicy):
     """Permissions for Community CRUD operations."""
 
     # Community
-    can_create = [AuthenticatedUser(), SystemProcess()]
+    _can_create = [AuthenticatedUser(), SystemProcess()]
+
+    can_create = [
+        IfConfig(
+            "RDM_COMMUNITY_REQUIRED_TO_PUBLISH",
+            then_=[CommunityCreator(), Administration(), SystemProcess()],
+            else_=_can_create,
+        )
+    ]
 
     can_read = [
         IfRestricted("visibility", then_=[CommunityMembers()], else_=[AnyUser()]),

--- a/invenio_communities/views/communities.py
+++ b/invenio_communities/views/communities.py
@@ -3,6 +3,7 @@
 # This file is part of Invenio.
 # Copyright (C) 2016-2024 CERN.
 # Copyright (C) 2023 Graz University of Technology.
+# Copyright (C) 2024 KTH Royal Institute of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -432,6 +433,15 @@ def communities_settings_submission_policy(pid_value, community, community_ui):
     if not permissions["can_update"]:
         raise PermissionDeniedError()
 
+    if current_app.config.get("RDM_COMMUNITY_REQUIRED_TO_PUBLISH", False):
+        # Restrict review policies when publishing with community is required
+        available_review_policies = [
+            policy for policy in REVIEW_POLICY_FIELDS if policy["value"] == "closed"
+        ]
+
+    else:
+        available_review_policies = REVIEW_POLICY_FIELDS
+
     return render_community_theme_template(
         "invenio_communities/details/settings/submission_policy.html",
         theme=community_ui.get("theme", {}),
@@ -439,7 +449,7 @@ def communities_settings_submission_policy(pid_value, community, community_ui):
         permissions=permissions,
         form_config=dict(
             access=dict(
-                review_policy=REVIEW_POLICY_FIELDS,
+                review_policy=available_review_policies,
                 record_submission_policy=RECORDS_SUBMISSION_POLICY_FIELDS,
             ),
         ),

--- a/tests/communities/test_community_ui_serializer.py
+++ b/tests/communities/test_community_ui_serializer.py
@@ -7,11 +7,17 @@
 
 """Resources serializers tests."""
 
+from collections import namedtuple
+from functools import partial
+
 from flask import g
+from flask_principal import Identity, RoleNeed
+from invenio_access.permissions import system_identity
 
 from invenio_communities.communities.resources.serializer import (
     UICommunityJSONSerializer,
 )
+from invenio_communities.permissions import CommunityPermissionPolicy
 
 
 def test_ui_serializer(app, community, users, any_user):
@@ -75,3 +81,227 @@ def test_ui_serializer(app, community, users, any_user):
         serialized_record["ui"]["permissions"]
         == require_review_expected_data["permissions"]
     )
+
+
+def test_can_include_directly_closed(
+    app,
+    db,
+    community,
+    anon_identity,
+    any_user,
+    superuser_identity,
+    owner,
+    community_service,
+):
+    """Test 'include_directly' permission with 'closed' review policy."""
+    # Set the community's review policy to 'closed'
+    community_data = community_service.read(system_identity, community.id).data
+    community_data["access"]["review_policy"] = "closed"
+    community_service.update(system_identity, community.id, community_data)
+    community_record = community_service.read(system_identity, community.id)
+
+    # Identities
+    anonymous_identity = anon_identity
+    authenticated_identity = any_user.identity
+    owner_identity = owner.identity
+    superuser_id = superuser_identity
+    system_process_identity = system_identity
+
+    # Community Creator
+    community_creator_identity = Identity(any_user.id)
+    community_creator_identity.provides.update(authenticated_identity.provides)
+    community_creator_identity.provides.add(RoleNeed("community-creator"))
+
+    # Community Member (Owner)
+    member_identity = Identity(owner.id)
+    member_identity.provides.update(owner_identity.provides)
+    # Assume owner is a member
+
+    _Need = namedtuple("Need", ["method", "value", "role"])
+    CommunityRoleNeed = partial(_Need, "community")
+    community_id = str(community.id)
+    member_identity.provides.add(CommunityRoleNeed(community_id, "member"))
+
+    # Community Curator
+    curator_identity = Identity(any_user.id)
+    curator_identity.provides.update(authenticated_identity.provides)
+    curator_identity.provides.add(CommunityRoleNeed(community_id, "curator"))
+
+    # Set RDM_COMMUNITY_REQUIRED_TO_PUBLISH to True
+    app.config["RDM_COMMUNITY_REQUIRED_TO_PUBLISH"] = True
+
+    policy = CommunityPermissionPolicy
+
+    # Assertions: No one can include directly
+    identities = [
+        anonymous_identity,
+        authenticated_identity,
+        community_creator_identity,
+        member_identity,
+        curator_identity,
+        owner_identity,
+        superuser_id,
+        system_process_identity,
+    ]
+
+    for identity in identities:
+        assert not policy(action="include_directly", record=community_record).allows(
+            identity
+        )
+
+    app.config["RDM_COMMUNITY_REQUIRED_TO_PUBLISH"] = False
+
+    # Assertions remain the same: No one can include directly
+    for identity in identities:
+        assert not policy(action="include_directly", record=community_record).allows(
+            identity
+        )
+
+
+def test_can_include_directly_open(
+    app,
+    db,
+    community,
+    anon_identity,
+    any_user,
+    superuser_identity,
+    owner,
+    community_service,
+):
+    """Test 'include_directly' permission with 'open' review policy."""
+    # Set the community's review policy to 'open'
+    community_data = community_service.read(system_identity, community.id).data
+    community_data["access"]["review_policy"] = "open"
+    community_service.update(system_identity, community.id, community_data)
+    community_record = community_service.read(system_identity, community.id)
+
+    # Identities
+    anonymous_identity = anon_identity
+    authenticated_identity = any_user.identity
+    owner_identity = owner.identity
+    system_process_identity = system_identity
+
+    # Create identities with roles
+    from flask_principal import Identity, RoleNeed
+
+    # Community Creator
+    community_creator_identity = Identity(any_user.id)
+    community_creator_identity.provides.update(authenticated_identity.provides)
+    community_creator_identity.provides.add(RoleNeed("community-creator"))
+
+    # Community Curator
+    from collections import namedtuple
+    from functools import partial
+
+    _Need = namedtuple("Need", ["method", "value", "role"])
+    CommunityRoleNeed = partial(_Need, "community")
+    community_id = str(community.id)
+    curator_identity = Identity(any_user.id)
+    curator_identity.provides.update(authenticated_identity.provides)
+    curator_identity.provides.add(CommunityRoleNeed(community_id, "curator"))
+
+    # Set RDM_COMMUNITY_REQUIRED_TO_PUBLISH to False
+    app.config["RDM_COMMUNITY_REQUIRED_TO_PUBLISH"] = False
+
+    policy = CommunityPermissionPolicy
+
+    # Assertions when RDM_COMMUNITY_REQUIRED_TO_PUBLISH is False
+    # Only community curators can include directly
+    # Superuser should not be allowed
+    assert not policy(action="include_directly", record=community_record).allows(
+        anonymous_identity
+    )
+    assert not policy(action="include_directly", record=community_record).allows(
+        authenticated_identity
+    )
+    assert not policy(action="include_directly", record=community_record).allows(
+        community_creator_identity
+    )
+
+    # Community curator can include directly
+    assert policy(action="include_directly", record=community_record).allows(
+        curator_identity
+    )
+
+
+def test_can_include_directly_members(
+    app,
+    db,
+    community,
+    anon_identity,
+    any_user,
+    superuser_identity,
+    owner,
+    community_service,
+):
+    """Test 'include_directly' permission with 'members' review policy."""
+    # Set the community's review policy to 'members'
+    community_data = community_service.read(system_identity, community.id).data
+    community_data["access"]["review_policy"] = "members"
+    community_service.update(system_identity, community.id, community_data)
+    community_record = community_service.read(system_identity, community.id)
+
+    # Identities
+    anonymous_identity = anon_identity
+    authenticated_identity = any_user.identity
+    owner_identity = owner.identity
+    superuser_id = superuser_identity
+    system_process_identity = system_identity
+
+    # Create identities with roles
+    from flask_principal import Identity, RoleNeed
+
+    # Community Creator
+    community_creator_identity = Identity(any_user.id)
+    community_creator_identity.provides.update(authenticated_identity.provides)
+    community_creator_identity.provides.add(RoleNeed("community-creator"))
+
+    # Community Member
+    member_identity = Identity(any_user.id)
+    member_identity.provides.update(authenticated_identity.provides)
+    from collections import namedtuple
+    from functools import partial
+
+    _Need = namedtuple("Need", ["method", "value", "role"])
+    CommunityRoleNeed = partial(_Need, "community")
+    community_id = str(community.id)
+    member_identity.provides.add(CommunityRoleNeed(community_id, "member"))
+
+    # Assume owner is a member
+    owner_member_identity = Identity(owner.id)
+    owner_member_identity.provides.update(owner_identity.provides)
+    owner_member_identity.provides.add(CommunityRoleNeed(community_id, "member"))
+
+    # Set RDM_COMMUNITY_REQUIRED_TO_PUBLISH to True
+    app.config["RDM_COMMUNITY_REQUIRED_TO_PUBLISH"] = True
+
+    policy = CommunityPermissionPolicy
+
+    # Assertions when RDM_COMMUNITY_REQUIRED_TO_PUBLISH is True
+    identities = [
+        anonymous_identity,
+        authenticated_identity,
+        community_creator_identity,
+        member_identity,
+    ]
+
+    # All users are denied
+    for identity in identities:
+        assert not policy(action="include_directly", record=community_record).allows(
+            identity
+        )
+
+    # Set RDM_COMMUNITY_REQUIRED_TO_PUBLISH to False
+    app.config["RDM_COMMUNITY_REQUIRED_TO_PUBLISH"] = False
+
+    # Assertions when RDM_COMMUNITY_REQUIRED_TO_PUBLISH is False
+    # Only community members can include directly
+    for identity in [
+        anonymous_identity,
+        authenticated_identity,
+        community_creator_identity,
+        system_process_identity,
+    ]:
+        assert not policy(action="include_directly", record=community_record).allows(
+            identity
+        )

--- a/tests/communities/test_permissions.py
+++ b/tests/communities/test_permissions.py
@@ -1,12 +1,15 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2024 Northwestern University.
+# Copyright (C) 2024 KTH Royal Institute of Technology.
 #
 # Invenio-RDM-Records is free software; you can redistribute it
 # and/or modify it under the terms of the MIT License; see LICENSE file for
 # more details.
 
 """Test permissions."""
+from flask_principal import Identity, RoleNeed
+from invenio_access.permissions import system_identity
 
 from invenio_communities.permissions import CommunityPermissionPolicy
 
@@ -61,3 +64,54 @@ def test_can_request_membership(
     )
 
     app.config["COMMUNITIES_ALLOW_MEMBERSHIP_REQUESTS"] = allow_membership_requests_orig
+
+
+def test_can_create(app, anon_identity, any_user, superuser_identity):
+    policy = CommunityPermissionPolicy
+
+    # Save the original configuration value
+    original_config = app.config.get("RDM_COMMUNITY_REQUIRED_TO_PUBLISH", False)
+
+    authenticated_identity = any_user.identity
+
+    # Create an identity for a user with the 'community-creator' role
+    # Copy the provides from authenticated_identity to ensure 'authenticated_user' is included
+    community_creator_identity = Identity(any_user.id)
+    community_creator_identity.provides.update(authenticated_identity.provides)
+    community_creator_identity.provides.add(RoleNeed("community-creator"))
+
+    # RDM_COMMUNITY_REQUIRED_TO_PUBLISH is True
+    app.config["RDM_COMMUNITY_REQUIRED_TO_PUBLISH"] = True
+
+    # Anonymous user cannot create communities
+    assert not policy(action="create").allows(anon_identity)
+
+    # Authenticated user without 'community-creator' role cannot create
+    assert not policy(action="create").allows(authenticated_identity)
+
+    # Authenticated user with 'community-creator' role can create
+    assert policy(action="create").allows(community_creator_identity)
+
+    # Superuser (admin) can create communities
+    assert policy(action="create").allows(superuser_identity)
+
+    # System process can create communities
+    assert policy(action="create").allows(system_identity)
+
+    # RDM_COMMUNITY_REQUIRED_TO_PUBLISH is False
+    app.config["RDM_COMMUNITY_REQUIRED_TO_PUBLISH"] = False
+
+    # Anonymous user cannot create communities
+    assert not policy(action="create").allows(anon_identity)
+
+    # Authenticated user without 'community-creator' role can create
+    assert policy(action="create").allows(authenticated_identity)
+
+    # Authenticated user with 'community-creator' role can create
+    assert policy(action="create").allows(community_creator_identity)
+
+    # Superuser (admin) can create communities
+    assert policy(action="create").allows(superuser_identity)
+
+    # System process can create communities
+    assert policy(action="create").allows(system_identity)


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

* The `can_create` permission will now have the option to check if `RDM_COMMUNITY_REQUIRED_TO_PUBLISH` is set to True, requiring the user to have the community manager role to create new communities.
* The community creator role name can be overridden from the user instance.
* Closes https://github.com/inveniosoftware/product-rdm/issues/183
* Update communities settings so it can always be closed if the config is True
![image](https://github.com/user-attachments/assets/4fa4d849-36b1-4aba-94d5-2a9062739f27)




### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
