### PR TITLE
settings-ui: fix organizations metadata payload

### DIFF
--- a/invenio_communities/assets/semantic-ui/js/invenio_communities/settings/profile/CommunityProfileForm.js
+++ b/invenio_communities/assets/semantic-ui/js/invenio_communities/settings/profile/CommunityProfileForm.js
@@ -470,6 +470,19 @@ class CommunityProfileForm extends Component {
                             []
                           )}
                           serializeSuggestions={(organizations) => {
+                            // Add organization IDs to known organizations
+                            organizations.forEach((organization) => {
+                              // eslint-disable-next-line no-prototype-builtins
+                              const isKnownOrg = this.knownOrganizations.hasOwnProperty(
+                                organization.name
+                              );
+                              if (!isKnownOrg) {
+                                this.knownOrganizations = {
+                                  ...this.knownOrganizations,
+                                  [organization.name]: organization.id,
+                                };
+                              }
+                            });
                             return AffiliationsSuggestions(organizations, true);
                           }}
                           label={


### PR DESCRIPTION
* Fixes a bug where organizations selected from the search in the
  profile form, should also submit the `id` so that it's linked to the
  affiliation vocabulary entry.
