### PR TITLE
Allow custom routes to be picked up by community links template

### DIFF
--- a/invenio_communities/communities/services/config.py
+++ b/invenio_communities/communities/services/config.py
@@ -42,7 +42,7 @@ from invenio_communities.communities.services.results import (
 from ...permissions import CommunityPermissionPolicy, can_perform_action
 from ..schema import CommunityFeaturedSchema, CommunitySchema, TombstoneSchema
 from .components import DefaultCommunityComponents
-from .links import CommunityLink
+from .links import CommunityLink, CommunityLinks
 from .search_params import IncludeDeletedCommunitiesParam, StatusParam
 from .sort import CommunitiesSortParam
 
@@ -114,25 +114,7 @@ class CommunityServiceConfig(RecordServiceConfig, ConfiguratorMixin):
     result_list_cls_featured = CommunityFeaturedList
     result_item_cls_featured = FeaturedCommunityItem
 
-    links_item = {
-        "self": CommunityLink("{+api}/communities/{id}"),
-        "self_html": CommunityLink("{+ui}/communities/{slug}"),
-        "settings_html": CommunityLink("{+ui}/communities/{slug}/settings"),
-        "logo": CommunityLink("{+api}/communities/{id}/logo"),
-        "rename": CommunityLink("{+api}/communities/{id}/rename"),
-        "members": CommunityLink("{+api}/communities/{id}/members"),
-        "public_members": CommunityLink("{+api}/communities/{id}/members/public"),
-        "invitations": CommunityLink("{+api}/communities/{id}/invitations"),
-        "requests": CommunityLink("{+api}/communities/{id}/requests"),
-        "records": CommunityLink("{+api}/communities/{id}/records"),
-        "subcommunities": CommunityLink(
-            "{+api}/communities/{id}/subcommunities",
-            when=children_allowed,
-        ),
-        "membership_requests": CommunityLink(
-            "{+api}/communities/{id}/membership-requests"
-        ),
-    }
+    links_item = CommunityLinks.get_item_links
 
     action_link = CommunityLink(
         "{+api}/communities/{id}/{action_name}", when=can_perform_action

--- a/invenio_communities/communities/services/service.py
+++ b/invenio_communities/communities/services/service.py
@@ -64,7 +64,7 @@ class CommunityService(RecordService):
     def links_item_tpl(self):
         """Item links template."""
         return CommunityLinksTemplate(
-            self.config.links_item,
+            self.config.links_item(),
             self.config.action_link,
             self.config.available_actions,
             context={

--- a/invenio_communities/config.py
+++ b/invenio_communities/config.py
@@ -37,6 +37,7 @@ COMMUNITIES_ROUTES = {
     "invitations": "/communities/<pid_value>/invitations",
     "about": "/communities/<pid_value>/about",
     "curation_policy": "/communities/<pid_value>/curation-policy",
+    "self": "/communities/<pid_value>",
 }
 
 """Communities ui endpoints."""


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

Currently changes to routes via the COMMUNITIES_ROUTES config variable do not affect the urls in the "links" property of community record results. This PR offers a fix which allows the community links template to pick up custom routes from the config variable.

There are two challenges to solving this issue:
1.  The config variables are not available to the CommunityServiceConfig when it is being initialized
2. The COMMUNITIES_ROUTES url templates use a different templating format than the links template does

I've attempted to solve #1 by delaying the actual creation of the link strings until after the app has been initialized and the config variables are available. Rather than building the link strings when CommunityServiceConfig is initialized, I move the link string construction into a factory class. That factory class is then called during the dumping of records to result objects, and since the `current_app` is available at that point, we can draw in the required COMMUNITIES_ROUTES variables.

I also include in the factory class some string conversion logic that converts the routes strings to the templating format used by the links template.

This may not be the ideal solution to this problem in the long run, but it does solve the problem and does so while allowing the COMMUNITIES_ROUTES to be a single source of truth for overridden routes.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
4. You agree that you have the right to license your contribution under the current repository’s license.
