### PR TITLE
js: add slug to subcommunity initial values

### DIFF
--- a/invenio_communities/assets/semantic-ui/js/invenio_communities/subcommunity/new.js
+++ b/invenio_communities/assets/semantic-ui/js/invenio_communities/subcommunity/new.js
@@ -179,6 +179,9 @@ class CommunityCreateForm extends Component {
               slug: "",
               title: "",
             },
+            metadata: {
+              slug: "",
+            }
           }}
           onSubmit={this.onSubmit}
         >


### PR DESCRIPTION
If the value is not present, the form will not render breaking here https://github.com/inveniosoftware/invenio-communities/blob/master/invenio_communities/assets/semantic-ui/js/invenio_communities/subcommunity/new.js#L38