### PR TITLE
Humanize byte size error for community image upload

### DIFF
--- a/invenio_communities/errors.py
+++ b/invenio_communities/errors.py
@@ -12,6 +12,8 @@ from math import ceil
 from flask_babel import ngettext
 from invenio_i18n import gettext as _
 
+from .utils import humanize_byte_size
+
 
 class CommunityError(Exception):
     """Base exception for community errors."""
@@ -44,10 +46,15 @@ class LogoSizeLimitError(CommunityError):
 
     def __init__(self, limit, file_size):
         """Initialise error."""
+        limit_value, limit_unit = humanize_byte_size(limit)
+        file_size_value, file_size_unit = humanize_byte_size(file_size)
         super().__init__(
             _(
-                "Logo size limit exceeded. Limit: {limit} bytes Given: {file_size} bytes".format(
-                    limit=ceil(limit), file_size=ceil(file_size)
+                "Logo size limit exceeded. Limit: {limit_value} {limit_unit} Given: {file_size_value} {file_size_unit}".format(
+                    limit_value=limit_value,
+                    limit_unit=limit_unit,
+                    file_size_value=file_size_value,
+                    file_size_unit=file_size_unit,
                 )
             )
         )

--- a/invenio_communities/utils.py
+++ b/invenio_communities/utils.py
@@ -8,6 +8,8 @@
 
 """Utilities."""
 
+from decimal import ROUND_HALF_UP, Decimal
+
 from flask import session
 from flask_principal import Identity
 from invenio_accounts.models import Role
@@ -109,3 +111,14 @@ def on_datastore_post_commit(sender, session):
             users = role.users.all()
             for user in users:
                 on_user_membership_change(Identity(user.id))
+
+
+def humanize_byte_size(size):
+    """Converts bytes to largest unit (e.g., KB, MB, GB)."""
+    BYTES_PER_UNIT = 1000
+    s = Decimal(size)
+    q = Decimal("0.00")
+    for unit in ["B", "KB", "MB", "GB", "TB", "PB"]:
+        if s < BYTES_PER_UNIT:
+            return s.quantize(q, rounding=ROUND_HALF_UP), unit
+        s /= BYTES_PER_UNIT

--- a/tests/communities/test_resources.py
+++ b/tests/communities/test_resources.py
@@ -689,6 +689,9 @@ def test_logo_max_content_length(
         data=BytesIO(logo_data),
     )
     assert res.status_code == 400
+    assert (
+        res.json["message"] == "Logo size limit exceeded. Limit: 1.00 MB Given: 4.00 MB"
+    )
 
     # Update logo with small content
     logo_data = b"logo"


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

Update logo size limit error to show humanized byte size error on community image upload. Add helper function to perform this conversion.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
