### PR TITLE
using translated string for displaying role

### DIFF
--- a/invenio_communities/assets/semantic-ui/js/invenio_communities/members/members/manager_view/ManagerMembersResultItem.js
+++ b/invenio_communities/assets/semantic-ui/js/invenio_communities/members/members/manager_view/ManagerMembersResultItem.js
@@ -148,6 +148,7 @@ export class ManagerMembersResultItem extends Component {
               label={i18next.t("Role") + " " + result.role}
             />
           ) : (
+            config?.allRoles?.find((role) => role.name === result.role)?.title ||
             _upperFirst(result.role)
           )}
         </Table.Cell>

--- a/invenio_communities/assets/semantic-ui/js/invenio_communities/members/members/manager_view/index.js
+++ b/invenio_communities/assets/semantic-ui/js/invenio_communities/members/members/manager_view/index.js
@@ -33,6 +33,7 @@ const ManagerMembersResultItemWithConfig = parametrize(ManagerMembersResultItem,
     rolesCanUpdate: communitiesRolesCanUpdate,
     visibility: memberVisibilityTypes,
     permissions: permissions,
+    allRoles: communitiesAllRoles,
   },
 });
 

--- a/invenio_communities/assets/semantic-ui/js/invenio_communities/members/members/member_view/index.js
+++ b/invenio_communities/assets/semantic-ui/js/invenio_communities/members/members/member_view/index.js
@@ -31,6 +31,7 @@ const ManagerMembersResultItemWithConfig = parametrize(ManagerMembersResultItem,
     rolesCanUpdate: communitiesRolesCanUpdate,
     visibility: memberVisibilityTypes,
     permissions: permissions,
+    allRoles: communitiesAllRoles,
   },
 });
 


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

There is an issue here that role is hardcoded in the members result list item https://github.com/inveniosoftware/invenio-communities/blob/7b9a1edd0e8a194e73349382d5e8320671c0bf90/invenio_communities/assets/semantic-ui/js/invenio_communities/members/members/manager_view/ManagerMembersResultItem.js#L142
![image](https://github.com/user-attachments/assets/dec730ab-8549-461e-aef2-e39a02e30b62)

Therefore, it is not possible to really change the content + not possible to localize.

This PR introduces a fix where we just additionally pass all roles to the ResultListItem and then we find the appropriate role's title. The users can configure the content of the text from invenio.cfg by using COMMUNITIES_ROLES variable.


