### PR TITLE
services: include Opensearch meta in the results

### DIFF
--- a/invenio_communities/communities/services/results.py
+++ b/invenio_communities/communities/services/results.py
@@ -57,6 +57,7 @@ class CommunityListResult(RecordList):
                 context=dict(
                     identity=self._identity,
                     record=record,
+                    meta=hit.meta,
                 ),
             )
             if self._links_item_tpl:


### PR DESCRIPTION
Sometimes, keys relevant to the serialization process are not included inside ``_source``, i.e. "highlight." By adding ``hit.meta`` as part of the serializer context, we make them available without the risk of name collision.