### PR TITLE
Fix subcommunity request parent ID reference

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -7,7 +7,6 @@
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
-import os
 
 from invenio_communities import __version__
 

--- a/invenio_communities/alembic/72b37bb4119c_create_indeces_for_bucket_id.py
+++ b/invenio_communities/alembic/72b37bb4119c_create_indeces_for_bucket_id.py
@@ -7,7 +7,6 @@
 
 """Create indeces for bucket_id."""
 
-import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.

--- a/invenio_communities/errors.py
+++ b/invenio_communities/errors.py
@@ -7,7 +7,6 @@
 
 """Community base error."""
 
-from math import ceil
 
 from flask_babel import ngettext
 from invenio_i18n import gettext as _

--- a/invenio_communities/ext.py
+++ b/invenio_communities/ext.py
@@ -10,7 +10,6 @@
 
 """Invenio communities extension."""
 
-from flask import g
 from flask_menu import current_menu
 from flask_principal import identity_loaded
 from invenio_accounts.signals import datastore_post_commit

--- a/invenio_communities/members/services/service.py
+++ b/invenio_communities/members/services/service.py
@@ -13,7 +13,6 @@ from datetime import datetime, timezone
 
 from flask import current_app
 from invenio_access.permissions import system_identity
-from invenio_accounts.models import Role
 from invenio_i18n import gettext as _
 from invenio_notifications.services.uow import NotificationOp
 from invenio_records_resources.services import LinksTemplate
@@ -33,7 +32,6 @@ from invenio_search.engine import dsl
 from kombu import Queue
 from marshmallow import ValidationError
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.orm.exc import NoResultFound
 from werkzeug.local import LocalProxy
 
 from ...notifications.builders import CommunityInvitationSubmittedNotificationBuilder

--- a/invenio_communities/requests/user_moderation/actions.py
+++ b/invenio_communities/requests/user_moderation/actions.py
@@ -15,9 +15,6 @@ from invenio_pidstore.errors import PIDDoesNotExistError
 from invenio_search.engine import dsl
 from invenio_vocabularies.proxies import current_service as vocab_service
 
-from invenio_communities.communities.records.systemfields.deletion_status import (
-    CommunityDeletionStatusEnum,
-)
 from invenio_communities.proxies import current_communities
 
 from .tasks import delete_community, restore_community

--- a/invenio_communities/subcommunities/resources/config.py
+++ b/invenio_communities/subcommunities/resources/config.py
@@ -22,9 +22,6 @@ from marshmallow import fields
 from invenio_communities.communities.resources.args import (
     CommunitiesSearchRequestArgsSchema,
 )
-from invenio_communities.communities.resources.serializer import (
-    UICommunityJSONSerializer,
-)
 
 from ..services.errors import ParentChildrenNotAllowed
 

--- a/invenio_communities/subcommunities/resources/resource.py
+++ b/invenio_communities/subcommunities/resources/resource.py
@@ -11,11 +11,8 @@ from flask_resources import Resource, resource_requestctx, response_handler, rou
 from invenio_records_resources.resources.errors import ErrorHandlersMixin
 from invenio_records_resources.resources.records.resource import (
     request_data,
-    request_extra_args,
-    request_search_args,
     request_view_args,
 )
-from invenio_records_resources.resources.records.utils import search_preference
 
 
 class SubCommunityResource(ErrorHandlersMixin, Resource):

--- a/invenio_communities/subcommunities/services/service.py
+++ b/invenio_communities/subcommunities/services/service.py
@@ -104,7 +104,7 @@ class SubCommunityService(Service):
         creator = {"community": str(community.id)}
 
         # Receiver is the parent community
-        receiver = {"community": str(id_)}
+        receiver = {"community": str(parent_community.id)}
 
         # Topic is the community
         topic = {"community": str(community.id)}
@@ -131,7 +131,7 @@ class SubCommunityService(Service):
         # Accept the request if the user is the owner of both communities
         is_owner_child = self._is_owner_of(identity, str(community.id))
 
-        is_owner_parent = self._is_owner_of(identity, str(id_))
+        is_owner_parent = self._is_owner_of(identity, str(parent_community.id))
         if is_owner_child and is_owner_parent:
             request = requests_service.execute_action(
                 identity, request.id, "accept", uow=uow

--- a/tests/communities/test_alembic.py
+++ b/tests/communities/test_alembic.py
@@ -16,11 +16,6 @@ from invenio_db.utils import alembic_test_context, drop_alembic_version_table
 # default. This means that when alembic creates the database vs when SQLAlchemy
 # creates the database there's a discrepancy. Importing the subjects model
 # here, ensures the model get's registered, and we avoid the discrepancy.
-from invenio_vocabularies.contrib.affiliations import models
-from invenio_vocabularies.contrib.awards import models
-from invenio_vocabularies.contrib.funders import models
-from invenio_vocabularies.contrib.names import models
-from invenio_vocabularies.contrib.subjects import models
 
 
 @pytest.mark.skip(reason="Caused by mergepoint")

--- a/tests/members/conftest.py
+++ b/tests/members/conftest.py
@@ -16,7 +16,6 @@ import pytest
 from invenio_access.permissions import system_identity
 from invenio_requests.records.api import Request
 from invenio_search import current_search
-from invenio_users_resources.proxies import current_users_service
 
 from invenio_communities.members.records.api import ArchivedInvitation, Member
 

--- a/tests/members/test_members_resource.py
+++ b/tests/members/test_members_resource.py
@@ -11,7 +11,6 @@
 import pytest
 from invenio_access.permissions import system_identity
 from invenio_requests.records.api import RequestEvent
-from invenio_users_resources.proxies import current_users_service
 
 
 #


### PR DESCRIPTION
- **chore: remove unused imports**
  

- **subcomunities: fix parent community ID referencing in request payload**
  * Instead of using the passed argument community ID (which could be a
    slug), use the resolved parent community object to reference in the
    request creation.
  