### PR TITLE
fix: internationalized additionLabel for community organizations pick…

### DIFF
--- a/invenio_communities/assets/semantic-ui/js/invenio_communities/settings/profile/CommunityProfileForm.js
+++ b/invenio_communities/assets/semantic-ui/js/invenio_communities/settings/profile/CommunityProfileForm.js
@@ -456,6 +456,7 @@ class CommunityProfileForm extends Component {
                         community={community}
                       >
                         <RemoteSelectField
+                          additionLabel={i18next.t("Add organization: ")}
                           fieldPath="metadata.organizations"
                           suggestionAPIUrl="/api/affiliations"
                           suggestionAPIHeaders={{


### PR DESCRIPTION

:heart: Thank you for your contribution!

### Description

NOTE: this was derived from https://github.com/inveniosoftware/invenio-communities/pull/1307
where based on comments from Tom and Christoph I will split that PR into more self contained PRs for easier reviewing and merging. After I make all derived PRs, I will close the original one.

On communities settings page, the organization selector, has untranslated additionLabel. 

![image](https://github.com/user-attachments/assets/b41b916e-fd8e-4cfd-9252-2adc36420564)

After changing:

![image](https://github.com/user-attachments/assets/a631fed1-93cb-4a34-bdd0-84887fd80c19)


Yes indeed this will change the UI in communities for everyone. I like to keep it as explicit is possible, because you are adding an organization to communitie's metadata. But if you don't like this string, we can do just i18next.t("Add"). 

Thanks for the review.




**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
