### PR TITLE
translations: wrapped user facing strings into i18next

### DIFF
--- a/invenio_communities/assets/semantic-ui/js/invenio_communities/members/Filters.js
+++ b/invenio_communities/assets/semantic-ui/js/invenio_communities/members/Filters.js
@@ -20,7 +20,7 @@ export class Filters {
     this.configRoles.forEach((role) => {
       values.push({ key: role.name, label: role.title });
     });
-    return this.serializeFilter("role", "Role", values);
+    return this.serializeFilter("role", i18next.t("Role"), values);
   }
 
   getVisibility() {
@@ -28,7 +28,7 @@ export class Filters {
       { key: "true", label: i18next.t("Public") },
       { key: "false", label: i18next.t("Hidden") },
     ];
-    return this.serializeFilter("visibility", "Visibility", values);
+    return this.serializeFilter("visibility", i18next.t("Visibility"), values);
   }
 
   getStatus() {
@@ -40,7 +40,7 @@ export class Filters {
       { key: "cancel", label: i18next.t("Cancel") },
       { key: "expired", label: i18next.t("Expired") },
     ];
-    return this.serializeFilter("status", "Status", values);
+    return this.serializeFilter("status", i18next.t("Status"), values);
   }
 
   getInvitationFilters() {


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

NOTE: this was derived from https://github.com/inveniosoftware/invenio-communities/pull/1307
where based on comments from Tom and Christoph I will split that PR into more self contained PRs for easier reviewing and merging. After I make all derived PRs, I will close the original one.

> Please describe briefly your pull request.

Certain strings in [Filters.js](https://github.com/inveniosoftware/invenio-communities/blob/52f5463dc78b7ae501e2a64611bee91243f3b93e/invenio_communities/assets/semantic-ui/js/invenio_communities/members/Filters.js#L4) component are not wrapped in i18next.t.

For example status. 

Before:

![image](https://github.com/user-attachments/assets/ad7d44d3-7764-4b9c-809e-4cec7f152081)


After:
![image](https://github.com/user-attachments/assets/e810d3da-6eac-4e95-8afa-03196f4c898a)


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
