### PR TITLE
translations: i18next.t instead of Trans for resultsPerPage component

### DIFF
--- a/invenio_communities/assets/semantic-ui/js/invenio_communities/members/invitations/InvitationsResults.js
+++ b/invenio_communities/assets/semantic-ui/js/invenio_communities/members/invitations/InvitationsResults.js
@@ -10,7 +10,7 @@ import React from "react";
 import { Grid } from "semantic-ui-react";
 import { ResultsPerPage, Pagination, ResultsList } from "react-searchkit";
 import PropTypes from "prop-types";
-import { Trans } from "react-i18next";
+import { i18next } from "@translations/invenio_communities/i18next";
 
 export const InvitationsResults = ({ paginationOptions, currentResultsState }) => {
   const { total } = currentResultsState.data;
@@ -36,9 +36,9 @@ export const InvitationsResults = ({ paginationOptions, currentResultsState }) =
             <ResultsPerPage
               values={paginationOptions.resultsPerPage}
               label={(cmp) => (
-                <Trans key="communitiesInvitationsResult" count={cmp}>
-                  {cmp} results per page
-                </Trans>
+                <>
+                  {cmp} {i18next.t("results per page")}
+                </>
               )}
             />
           </Grid.Column>

--- a/invenio_communities/assets/semantic-ui/js/invenio_communities/members/members/components/MembersResult.js
+++ b/invenio_communities/assets/semantic-ui/js/invenio_communities/members/members/components/MembersResult.js
@@ -13,7 +13,6 @@ import { i18next } from "@translations/invenio_communities/i18next";
 import { ModalContextProvider } from "../../components/modal_manager";
 import RemoveMemberModal from "../../components/RemoveMemberModal";
 import PropTypes from "prop-types";
-import { Trans } from "react-i18next";
 
 export const MembersResults = ({ paginationOptions, currentResultsState }) => {
   const { total } = currentResultsState.data;
@@ -58,9 +57,9 @@ export const MembersResults = ({ paginationOptions, currentResultsState }) => {
             <ResultsPerPage
               values={paginationOptions.resultsPerPage}
               label={(cmp) => (
-                <Trans key="communitiesMembersResult" count={cmp}>
-                  {cmp} results per page
-                </Trans>
+                <>
+                  {cmp} {i18next.t("results per page")}
+                </>
               )}
             />
           </Grid.Column>


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

NOTE: this was derived from https://github.com/inveniosoftware/invenio-communities/pull/1307
where based on comments from Tom and Christoph I will split that PR into more self contained PRs for easier reviewing and merging. After I make all derived PRs, I will close the original one.

> Please describe briefly your pull request.

Results per page component is not localized properly (members and invitations pages):

![image](https://github.com/user-attachments/assets/14c8cb4c-6f3b-4ad7-a05e-49aec625f9ff)

![image](https://github.com/user-attachments/assets/fa7c04d6-1c1d-4f1e-bb90-b408df39f737)

The reason is that Trans component is used incorrectly:

```
  <Trans key="communitiesMembersResult" count={cmp}>
                  {cmp} results per page
                </Trans>
```

1.  Key is incorrect prop - should be i18nKey
2.  You cannot pass a component as a prop, but rather some interpolated value 
3. These two search apps are not wrapped by I18nextProvider and this means, if you wish for ```<Trans/>```
to work properly, you must pass it i18n prop (specific i18next instance).

From my point of view, I see no added benefits for using Trans here, just added complexity, so my proposal is to just use i18next.t instead.




**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
5. You agree that you have the right to license your contribution under the current repository’s license.
