### PR TITLE
feat (services): allow custom schema and record class

### DIFF
--- a/invenio_communities/communities/services/config.py
+++ b/invenio_communities/communities/services/config.py
@@ -90,7 +90,7 @@ class CommunityServiceConfig(RecordServiceConfig, ConfiguratorMixin):
         "COMMUNITIES_PERMISSION_POLICY", default=CommunityPermissionPolicy
     )
     # Record specific configuration
-    record_cls = Community
+    record_cls = FromConfig("COMMUNITIES_COMMUNITY_CLS", default=Community)
     result_item_cls = CommunityItem
     result_list_cls = CommunityListResult
     indexer_queue_name = "communities"
@@ -104,7 +104,7 @@ class CommunityServiceConfig(RecordServiceConfig, ConfiguratorMixin):
     )
 
     # Service schema
-    schema = CommunitySchema
+    schema = FromConfig("COMMUNITIES_COMMUNITY_SCHEMA", default=CommunitySchema)
     schema_featured = CommunityFeaturedSchema
     schema_tombstone = TombstoneSchema
 

--- a/invenio_communities/config.py
+++ b/invenio_communities/config.py
@@ -9,18 +9,33 @@
 from datetime import timedelta
 
 from invenio_i18n import lazy_gettext as _
+from invenio_records_resources.services.records.components import MetadataComponent
 from invenio_requests.services.requests import facets as facets_for_requests
 
 from invenio_communities.communities.records.api import Community
 from invenio_communities.communities.records.systemfields.access import (
     RecordSubmissionPolicyEnum,
 )
+from invenio_communities.communities.resources.config import (
+    community_error_handlers,
+)
 from invenio_communities.communities.schema import CommunitySchema
 from invenio_communities.communities.services import facets
+from invenio_communities.communities.services.components import (
+    DefaultCommunityComponents,
+)
+from invenio_communities.members.services.components import (
+    CommunityMemberCachingComponent,
+)
 from invenio_communities.permissions import CommunityPermissionPolicy
+from invenio_communities.subcommunities.services.request import SubCommunityRequest
+from invenio_communities.subcommunities.services.schema import SubcommunityRequestSchema
 
 COLLECTIONS_PERMISSION_POLICY = CommunityPermissionPolicy
 """Permission policy used by invenio-collections for managing collection trees."""
+
+COMMUNITIES_PERMISSION_POLICY = CommunityPermissionPolicy
+"""Permission policy for communities."""
 
 COMMUNITIES_ROUTES = {
     "frontpage": "/communities",
@@ -378,3 +393,21 @@ COMMUNITIES_COMMUNITY_CLS = Community
 
 COMMUNITIES_COMMUNITY_SCHEMA = CommunitySchema
 """Community schema."""
+
+COMMUNITIES_ERROR_HANDLERS = community_error_handlers
+"""Community resource error handlers."""
+
+COMMUNITIES_SERVICE_COMPONENTS = DefaultCommunityComponents
+"""Community service components."""
+
+COMMUNITIES_MEMBERS_SERVICE_COMPONENTS = [
+    MetadataComponent,
+    CommunityMemberCachingComponent,
+]
+"""Community members service components."""
+
+COMMUNITIES_SUB_SERVICE_SCHEMA = SubcommunityRequestSchema
+"""Subcommunity service schema."""
+
+COMMUNITIES_SUB_REQUEST_CLS = SubCommunityRequest
+"""Subcommunity request class."""

--- a/invenio_communities/config.py
+++ b/invenio_communities/config.py
@@ -11,9 +11,11 @@ from datetime import timedelta
 from invenio_i18n import lazy_gettext as _
 from invenio_requests.services.requests import facets as facets_for_requests
 
+from invenio_communities.communities.records.api import Community
 from invenio_communities.communities.records.systemfields.access import (
     RecordSubmissionPolicyEnum,
 )
+from invenio_communities.communities.schema import CommunitySchema
 from invenio_communities.communities.services import facets
 from invenio_communities.permissions import CommunityPermissionPolicy
 
@@ -369,4 +371,10 @@ COMMUNITIES_DEFAULT_RECORD_SUBMISSION_POLICY = RecordSubmissionPolicyEnum.OPEN
 """Default value of record submission policy community access setting."""
 
 COMMUNITIES_COLLECTIONS_ENABLED = False
-"""Feature flag to enable/disable collections feature."""
+"""Fe cvature flag to enable/disable collections feature."""
+
+COMMUNITIES_COMMUNITY_CLS = Community
+"""Community record class."""
+
+COMMUNITIES_COMMUNITY_SCHEMA = CommunitySchema
+"""Community schema."""


### PR DESCRIPTION
What would be the best way to document these configuration variables?

Inside RDM-Records, there is no reference to their counterpart in `config.py`, yet I feel it might be a good idea to add them there with the default value, so that they are somehow discoverable.