### PR TITLE
feat: add member name to kommunity member removal modal

### DIFF
--- a/invenio_communities/assets/semantic-ui/js/invenio_communities/members/components/RemoveMemberModal.js
+++ b/invenio_communities/assets/semantic-ui/js/invenio_communities/members/components/RemoveMemberModal.js
@@ -26,8 +26,14 @@ class RemoveMemberModal extends Component {
       error: "",
       loading: false,
     };
+  }
 
-    this.contentMap = {
+  static contextType = ModalContext;
+
+  getContentMap = () => {
+    const { member } = this.context;
+
+    return {
       [modalModeEnum.leave]: {
         headerText: i18next.t("Leave community"),
         bodyText: i18next.t("You are about to leave this community."),
@@ -36,14 +42,16 @@ class RemoveMemberModal extends Component {
       },
       [modalModeEnum.remove]: {
         headerText: i18next.t("Remove user"),
-        bodyText: i18next.t("You are about to remove this user from this community."),
+        bodyText: member
+          ? i18next.t("You are about to remove {{name}} from this community.", {
+              name: member.name,
+            })
+          : i18next.t("You are about to remove this user from this community."),
         buttonText: i18next.t("Remove"),
         buttonIcon: "user delete",
       },
     };
-  }
-
-  static contextType = ModalContext;
+  };
 
   onActionHandler = async () => {
     const { modalAction } = this.context;
@@ -69,7 +77,7 @@ class RemoveMemberModal extends Component {
     const { loading, error } = this.state;
     const { modalOpen, modalMode } = this.context;
 
-    const content = this.contentMap[modalMode];
+    const content = this.getContentMap()[modalMode];
 
     return (
       <Overridable
@@ -78,7 +86,7 @@ class RemoveMemberModal extends Component {
         modalMode={modalMode}
         modalAction={this.onActionHandler}
         closeModal={this.onCloseHandler}
-        contentMap={this.contentMap}
+        contentMap={this.getContentMap()}
       >
         <Modal open={modalOpen} role="dialog" aria-label={i18next.t("Remove user")}>
           <Modal.Header>{content?.headerText}</Modal.Header>

--- a/invenio_communities/assets/semantic-ui/js/invenio_communities/members/components/modal_manager/ModalContextProvider.js
+++ b/invenio_communities/assets/semantic-ui/js/invenio_communities/members/components/modal_manager/ModalContextProvider.js
@@ -18,11 +18,12 @@ export class ModalContextProvider extends Component {
       modalMode: null,
       modalAction: null,
       modalOpen: false,
+      member: null,
     };
   }
 
-  openModal = ({ modalAction, modalMode }) => {
-    this.setState({ modalOpen: true, modalAction, modalMode });
+  openModal = ({ modalAction, modalMode, member }) => {
+    this.setState({ modalOpen: true, modalAction, modalMode, member });
   };
 
   closeModal = () => {
@@ -31,7 +32,7 @@ export class ModalContextProvider extends Component {
 
   render() {
     const { children } = this.props;
-    const { modalMode, modalAction, modalOpen } = this.state;
+    const { modalMode, modalAction, modalOpen, member } = this.state;
 
     return (
       <ModalContext.Provider
@@ -41,6 +42,7 @@ export class ModalContextProvider extends Component {
           modalMode,
           modalAction,
           modalOpen,
+          member,
         }}
       >
         {children}

--- a/invenio_communities/assets/semantic-ui/js/invenio_communities/members/members/manager_view/ManagerMembersResultItem.js
+++ b/invenio_communities/assets/semantic-ui/js/invenio_communities/members/members/manager_view/ManagerMembersResultItem.js
@@ -54,7 +54,7 @@ export class ManagerMembersResultItem extends Component {
     const modalAction = () => api.removeMember(member);
     const modalMode = isRemoving ? modalModeEnum.remove : modalModeEnum.leave;
 
-    openModalCallback({ modalMode, modalAction });
+    openModalCallback({ modalMode, modalAction, member });
   };
 
   render() {


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description


Modal for removal of member from the community does not contain the name of the member you are removing. Sometimes if user missclicks, or they are not sure which member they clicked, they need to go back to the main view and check.

Before


<img width="1042" height="257" alt="image" src="https://github.com/user-attachments/assets/81fee828-b28a-4a1c-9ad3-c2397d622c9a" />



After 

<img width="1044" height="277" alt="image" src="https://github.com/user-attachments/assets/3291c370-13c7-409d-b004-200a65e6001d" />




### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
