### PR TITLE
feat: added overridable blocks around community invitations modal

### DIFF
--- a/invenio_communities/assets/semantic-ui/js/invenio_communities/members/invitations/InvitationsEmptyResults.js
+++ b/invenio_communities/assets/semantic-ui/js/invenio_communities/members/invitations/InvitationsEmptyResults.js
@@ -5,6 +5,7 @@ import { withState } from "react-searchkit";
 import { i18next } from "@translations/invenio_communities/i18next";
 import { InvitationsContextProvider } from "../../api/invitations/InvitationsContextProvider";
 import { InvitationsMembersModalWithSearchKit } from "./invitationsModal/InvitationsMembersModal";
+import Overridable from "react-overridable";
 
 class InvitationsEmptyResultsCmp extends Component {
   render() {
@@ -23,11 +24,18 @@ class InvitationsEmptyResultsCmp extends Component {
           <Grid.Column width="13" />
           <Grid.Column width="3">
             <InvitationsContextProvider community={community}>
-              <InvitationsMembersModalWithSearchKit
+              <Overridable
+                id="InvenioCommunities.CommunityMembersSearch.InvitationsEmptyResults.InvitationsModal.container"
                 rolesCanInvite={rolesCanInvite}
                 groupsEnabled={groupsEnabled}
                 community={community}
-              />
+              >
+                <InvitationsMembersModalWithSearchKit
+                  rolesCanInvite={rolesCanInvite}
+                  groupsEnabled={groupsEnabled}
+                  community={community}
+                />
+              </Overridable>
             </InvitationsContextProvider>
           </Grid.Column>
         </Segment>

--- a/invenio_communities/assets/semantic-ui/js/invenio_communities/members/invitations/InvitationsResultsContainer.js
+++ b/invenio_communities/assets/semantic-ui/js/invenio_communities/members/invitations/InvitationsResultsContainer.js
@@ -12,6 +12,7 @@ import PropTypes from "prop-types";
 import { Table } from "semantic-ui-react";
 import { InvitationsContextProvider } from "../../api/invitations/InvitationsContextProvider";
 import { InvitationsMembersModalWithSearchKit } from "./invitationsModal/InvitationsMembersModal";
+import Overridable from "react-overridable";
 
 export const InvitationsResultsContainer = ({
   results,
@@ -29,12 +30,19 @@ export const InvitationsResultsContainer = ({
           <Table.HeaderCell width={3}>{i18next.t("Role")}</Table.HeaderCell>
           <Table.HeaderCell width={1} textAlign="right">
             <InvitationsContextProvider community={community}>
-              <InvitationsMembersModalWithSearchKit
+              <Overridable
+                id="InvenioCommunities.CommunityMembersSearch.InvitationsResultsContainer.InvitationsModal.container"
                 rolesCanInvite={rolesCanInvite}
                 groupsEnabled={groupsEnabled}
                 community={community}
-                triggerButtonSize="tiny"
-              />
+              >
+                <InvitationsMembersModalWithSearchKit
+                  rolesCanInvite={rolesCanInvite}
+                  groupsEnabled={groupsEnabled}
+                  community={community}
+                  triggerButtonSize="tiny"
+                />
+              </Overridable>
             </InvitationsContextProvider>
           </Table.HeaderCell>
         </Table.Row>

--- a/invenio_communities/assets/semantic-ui/js/invenio_communities/members/invitations/InvitationsSearchLayout.js
+++ b/invenio_communities/assets/semantic-ui/js/invenio_communities/members/invitations/InvitationsSearchLayout.js
@@ -16,6 +16,7 @@ import { InvitationsMembersModalWithSearchKit } from "./invitationsModal/Invitat
 import { SearchBar, Sort } from "react-searchkit";
 import { FilterLabels } from "../components/FilterLabels";
 import { SearchFilters } from "@js/invenio_search_ui/components/SearchFilters";
+import Overridable from "react-overridable";
 
 export class InvitationsSearchLayout extends Component {
   render() {
@@ -34,11 +35,18 @@ export class InvitationsSearchLayout extends Component {
               <RequestStatusFilter keepFiltersOnUpdate />
               <div>
                 <InvitationsContextProvider community={community}>
-                  <InvitationsMembersModalWithSearchKit
+                  <Overridable
+                    id="InvenioCommunities.CommunityMembersSearch.InvitationsSearchLayout.InvitationsModal.container"
                     rolesCanInvite={rolesCanInvite}
                     groupsEnabled={groupsEnabled}
                     community={community}
-                  />
+                  >
+                    <InvitationsMembersModalWithSearchKit
+                      rolesCanInvite={rolesCanInvite}
+                      groupsEnabled={groupsEnabled}
+                      community={community}
+                    />
+                  </Overridable>
                 </InvitationsContextProvider>
               </div>
             </div>
@@ -51,11 +59,18 @@ export class InvitationsSearchLayout extends Component {
           <div className="flex align-items-center column-mobile">
             <div className="tablet only mr-5">
               <InvitationsContextProvider community={community}>
-                <InvitationsMembersModalWithSearchKit
+                <Overridable
+                  id="InvenioCommunities.CommunityMembersSearch.InvitationsSearchLayout.InvitationsModal.container"
                   rolesCanInvite={rolesCanInvite}
                   groupsEnabled={groupsEnabled}
                   community={community}
-                />
+                >
+                  <InvitationsMembersModalWithSearchKit
+                    rolesCanInvite={rolesCanInvite}
+                    groupsEnabled={groupsEnabled}
+                    community={community}
+                  />
+                </Overridable>
               </InvitationsContextProvider>
             </div>
 

--- a/invenio_communities/assets/semantic-ui/js/invenio_communities/members/members/manager_view/ManagerEmptyResults.js
+++ b/invenio_communities/assets/semantic-ui/js/invenio_communities/members/members/manager_view/ManagerEmptyResults.js
@@ -5,6 +5,7 @@ import { withState } from "react-searchkit";
 import { i18next } from "@translations/invenio_communities/i18next";
 import { InvitationsContextProvider } from "../../../api/invitations/InvitationsContextProvider";
 import { InvitationsMembersModalWithSearchKit } from "../../invitations/invitationsModal/InvitationsMembersModal";
+import Overridable from "react-overridable";
 
 class ManagerEmptyResultsCmp extends Component {
   render() {
@@ -23,11 +24,18 @@ class ManagerEmptyResultsCmp extends Component {
           <Grid.Column width="13" />
           <Grid.Column width="3">
             <InvitationsContextProvider community={community}>
-              <InvitationsMembersModalWithSearchKit
+              <Overridable
+                id="InvenioCommunities.CommunityMembersSearch.ManagerEmptyResults.InvitationsModal.container"
                 rolesCanInvite={rolesCanInvite}
                 groupsEnabled={groupsEnabled}
                 community={community}
-              />
+              >
+                <InvitationsMembersModalWithSearchKit
+                  rolesCanInvite={rolesCanInvite}
+                  groupsEnabled={groupsEnabled}
+                  community={community}
+                />
+              </Overridable>
             </InvitationsContextProvider>
           </Grid.Column>
         </Segment>

--- a/invenio_communities/assets/semantic-ui/js/invenio_communities/members/members/manager_view/ManagerMembersResultContainer.js
+++ b/invenio_communities/assets/semantic-ui/js/invenio_communities/members/members/manager_view/ManagerMembersResultContainer.js
@@ -12,6 +12,7 @@ import { InvitationsContextProvider } from "../../../api/invitations/Invitations
 import { InvitationsMembersModalWithSearchKit } from "../../invitations/invitationsModal/InvitationsMembersModal";
 import { Table } from "semantic-ui-react";
 import { ManagerMemberBulkActions } from "./ManagerMemberBulkActions";
+import Overridable from "react-overridable";
 
 export const ManagerMembersResultsContainer = ({
   results,
@@ -38,12 +39,19 @@ export const ManagerMembersResultsContainer = ({
           <Table.HeaderCell width={2}>{i18next.t("Role")}</Table.HeaderCell>
           <Table.HeaderCell width={2} textAlign="right">
             <InvitationsContextProvider community={community}>
-              <InvitationsMembersModalWithSearchKit
+              <Overridable
+                id="InvenioCommunities.CommunityMembersSearch.ManagerMembersResultsContainer.InvitationsModal.container"
                 rolesCanInvite={rolesCanInvite}
                 groupsEnabled={groupsEnabled}
                 community={community}
-                triggerButtonSize="tiny"
-              />
+              >
+                <InvitationsMembersModalWithSearchKit
+                  rolesCanInvite={rolesCanInvite}
+                  groupsEnabled={groupsEnabled}
+                  community={community}
+                  triggerButtonSize="tiny"
+                />
+              </Overridable>
             </InvitationsContextProvider>
           </Table.HeaderCell>
         </Table.Row>

--- a/invenio_communities/assets/semantic-ui/js/invenio_communities/members/members/manager_view/ManagerSearchLayout.js
+++ b/invenio_communities/assets/semantic-ui/js/invenio_communities/members/members/manager_view/ManagerSearchLayout.js
@@ -15,6 +15,7 @@ import { SearchFilters } from "@js/invenio_search_ui/components";
 import { SearchBar, Sort } from "react-searchkit";
 import { InvitationsContextProvider } from "../../../api/invitations/InvitationsContextProvider";
 import { InvitationsMembersModalWithSearchKit } from "../../invitations/invitationsModal/InvitationsMembersModal";
+import Overridable from "react-overridable";
 
 export class ManagerSearchLayout extends Component {
   render() {
@@ -29,11 +30,18 @@ export class ManagerSearchLayout extends Component {
           <div>
             <div className="mobile only rel-mb-1">
               <InvitationsContextProvider community={community}>
-                <InvitationsMembersModalWithSearchKit
+                <Overridable
+                  id="InvenioCommunities.CommunityMembersSearch.ManagerSearchLayout.InvitationsModal.container"
                   rolesCanInvite={rolesCanInvite}
                   groupsEnabled={groupsEnabled}
                   community={community}
-                />
+                >
+                  <InvitationsMembersModalWithSearchKit
+                    rolesCanInvite={rolesCanInvite}
+                    groupsEnabled={groupsEnabled}
+                    community={community}
+                  />
+                </Overridable>
               </InvitationsContextProvider>
             </div>
             <SearchBar fluid />
@@ -42,11 +50,18 @@ export class ManagerSearchLayout extends Component {
           <div className="flex align-items-center column-mobile">
             <div className="tablet only">
               <InvitationsContextProvider community={community}>
-                <InvitationsMembersModalWithSearchKit
+                <Overridable
+                  id="InvenioCommunities.CommunityMembersSearch.ManagerSearchLayout.InvitationsModal.container"
                   rolesCanInvite={rolesCanInvite}
                   groupsEnabled={groupsEnabled}
                   community={community}
-                />
+                >
+                  <InvitationsMembersModalWithSearchKit
+                    rolesCanInvite={rolesCanInvite}
+                    groupsEnabled={groupsEnabled}
+                    community={community}
+                  />
+                </Overridable>
               </InvitationsContextProvider>
             </div>
 


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description


It is not possible currently to override the community invitations modal. This PR adds overridable block around each instance where the community invitations modal appears.

For example, in our case, the community addition is done in an external system and then sychronized back to the repository and it is beneficial that we are able to provide our own UI for the invitations modal.


Thanks a lot for taking a look.


