### PR TITLE
feat: added blocks to communities templates

### DIFF
--- a/invenio_communities/templates/semantic-ui/invenio_communities/details/header.html
+++ b/invenio_communities/templates/semantic-ui/invenio_communities/details/header.html
@@ -42,6 +42,7 @@
   class="ui container fluid page-subheader-outer with-submenu rel-pt-2 ml-0-mobile mr-0-mobile">
   <div class="ui container relaxed grid page-subheader mr-0-mobile ml-0-mobile">
     <div class="row pb-0">
+      {%- block subheader_metadata %}
       <div
         class="sixteen wide mobile sixteen wide tablet eleven wide computer column">
         <div
@@ -111,6 +112,8 @@
           </div>
         </div>
       </div>
+      {%- endblock subheader_metadata %}
+      {%- block subheader_buttons %}
       <div
         class="sixteen wide mobile sixteen wide tablet five wide computer right aligned middle aligned column">
         {# Button to request membership is fully disabled until feature completely merged in v14. #}
@@ -135,11 +138,11 @@
             {{ _("Manage community") }}
           </a>
         {% endif %}
-
       </div>
-
+      {%- endblock subheader_buttons %}
     </div>
     <div class="ui divider mobile only"></div>
+    {%- block subheader_menu %}
     <div
       class="ui container secondary pointing stackable menu page-subheader pl-0 pr-0 theme-primary">
       {% if community_menu_active %}
@@ -154,5 +157,6 @@
         {% endfor %}
       {% endif %}
     </div>
+    {%- endblock subheader_menu %}
   </div>
 </div>

--- a/invenio_communities/templates/semantic-ui/invenio_communities/frontpage.html
+++ b/invenio_communities/templates/semantic-ui/invenio_communities/frontpage.html
@@ -32,6 +32,7 @@
         </p>
       </div>
     </div>
+    {%- block searchbar %}
     <div class="two column stackable row">
       <div class="eight wide tablet five wide computer column mt-auto mb-auto">
         <form action="{{ url_for('invenio_communities.communities_search') }}" class="ui form">
@@ -62,10 +63,12 @@
         </div>
       {% endif %}
     </div>
+    {%- endblock searchbar %}
     <div class="ui divider hidden"></div>
   </div>
 </div>
 <div class="ui container communities-frontpage rel-mt-3 rel-mb-2">
+  {%- block user_communities %}
   {% if current_user.is_authenticated %}
     <div class="flex">
       <h2 class="ui header mb-0 align-self-center">{{_('My communities')}}</h2>
@@ -76,6 +79,8 @@
     <div class="ui divider hidden"></div>
     <div id="user-communities" class="rel-mb-2"></div>
   {% endif %}
+  {%- endblock user_communities %}
+  {%- block new_communities %}
   <div class="ui divider"></div>
   <div class="flex">
     <h2 class="ui header mb-0 align-self-center">{{ _('New communities') }}</h2>
@@ -85,5 +90,6 @@
   </div>
   <div class="ui divider hidden"></div>
   <div id="new-communities"></div>
+  {%- endblock new_communities %}
 </div>
 {%- endblock page_body %}

--- a/invenio_communities/templates/semantic-ui/invenio_communities/search.html
+++ b/invenio_communities/templates/semantic-ui/invenio_communities/search.html
@@ -20,13 +20,14 @@
 <div class="ui container fluid page-subheader-outer compact ml-0-mobile mr-0-mobile">
   <div class="ui container community-search page-subheader flex align-items-center justify-space-between">
     <h1 class="ui large header m-0">{{_("Communities")}}</h1>
-
+    {%- block new_community_button %}
     {% if permissions.can_create %}
       <a class="ui button positive left labeled icon m-0" href="{{ config.COMMUNITIES_ROUTES['new'] }}">
         <i class="plus icon" aria-hidden="true"></i>
         {{ _('New community') }}
       </a>
     {% endif %}
+    {%- endblock new_community_button %}
   </div>
 </div>
 <div id="communities-search" class="rel-mt-2"


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

We make a lot of apps based on Invenio system, and sometimes. We try to maximise reuse of existing front and. It is sometimes necessary to override certain behaviors, but then we need to copy paste the entire template and modify, which is not ideal and we also later lose access to new features as templates evolve. We think that adding overridable blocks to these templates is also generally beneficial for the ecosystem, but for us we have concrete needs to override these blocks.

Please if possible to merge this.

Thank you,

Dusan S (CESNET)




