### PR TITLE
request membership part 4 member request interaction backend

### DIFF
--- a/invenio_communities/members/resources/resource.py
+++ b/invenio_communities/members/resources/resource.py
@@ -39,6 +39,9 @@ class MemberResource(RecordResource):
             route(
                 "GET", routes["membership_requests"], self.search_membership_requests
             ),
+            route(
+                "PUT", routes["membership_requests"], self.update_membership_requests
+            ),
         ]
 
     @request_view_args
@@ -143,6 +146,17 @@ class MemberResource(RecordResource):
     @request_data
     def update_invitations(self):
         """Update invitations."""
+        self.service.update(
+            g.identity,
+            resource_requestctx.view_args["pid_value"],
+            data=resource_requestctx.data,
+        )
+        return "", 204
+
+    @request_view_args
+    @request_data
+    def update_membership_requests(self):
+        """Update membership requests."""
         self.service.update(
             g.identity,
             resource_requestctx.view_args["pid_value"],

--- a/invenio_communities/members/services/components.py
+++ b/invenio_communities/members/services/components.py
@@ -53,8 +53,8 @@ class CommunityMemberCachingComponent(ServiceComponent):
         for user_id in user_ids:
             on_user_membership_change(Identity(user_id))
 
-    def accept_invite(self, identity, record=None, data=None, **kwargs):
-        """On accept invite."""
+    def accept_member_request(self, identity, record=None, data=None, **kwargs):
+        """On accept invite or membership request."""
         self._member_changed(record)
 
     def members_add(self, identity, record=None, community=None, data=None, **kwargs):

--- a/invenio_communities/members/services/config.py
+++ b/invenio_communities/members/services/config.py
@@ -25,6 +25,7 @@ from ..records import Member
 from ..records.api import ArchivedMemberRequest
 from . import facets
 from .components import CommunityMemberCachingComponent
+from .links import MemberRequestActionsEndpointLinks
 from .schemas import MemberEntitySchema
 
 
@@ -170,7 +171,7 @@ class MemberServiceConfig(RecordServiceConfig, ConfiguratorMixin):
 
     archive_cls = ArchivedMemberRequest
     archive_indexer_cls = RecordServiceConfig.indexer_cls
-    archive_indexer_queue_name = "archived-invitations"
+    archive_indexer_queue_name = "archived-invitations"  # legacy name
 
     permission_policy_cls = FromConfig(
         "COMMUNITIES_PERMISSION_POLICY", default=CommunityPermissionPolicy
@@ -179,9 +180,9 @@ class MemberServiceConfig(RecordServiceConfig, ConfiguratorMixin):
     search_public = PublicSearchOptions
     search_invitations = InvitationsSearchOptions
 
-    # No links
-    links_item = {}
-
+    links_item = {
+        "actions": MemberRequestActionsEndpointLinks(),
+    }
     # ResultList configurations
     links_search = pagination_endpoint_links(
         "community_members.search", params=["pid_value"]

--- a/invenio_communities/members/services/links.py
+++ b/invenio_communities/members/services/links.py
@@ -1,0 +1,153 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2026 Northwestern University.
+#
+# Invenio-Communities is free software; you can redistribute it and/or modify
+# it under the terms of the MIT License; see LICENSE file for more details.
+
+"""Members Service links."""
+
+from invenio_records_resources.services.base.links import (
+    EndpointLink,
+)
+from invenio_requests.proxies import current_request_type_registry
+
+from .request import CommunityInvitation, MembershipRequestRequestType
+
+
+def _can_execute(request_action, request_status):
+    """Reprise logic of `RequestActions.can_execute` without actual api.Request."""
+    if request_action.status_from is None:
+        return request_status is None
+    else:
+        return request_status in request_action.status_from
+
+
+def _is_context_action_possible(member, context):
+    """Check if the action (in context) for the member's request is possible.
+
+    Does equivalent of `RequestActions.can_execute` (equivalent of permission check is
+    done in `MemberRequestActionsEndpointLinks._available_action_ids_for_member`).
+    This is more "in case" as the status should always be 'submitted' at this point
+    barring manual intervention.
+
+    Assumptions at this point:
+    - member has a request
+    - context has action
+
+    :param member: api.Member (where Member represents an invitation or mshp request)
+    :param context: dict
+    """
+    action_id = context["action"]
+    request_type_id = member["request"].get("type", "community-invitation")
+    request_type = current_request_type_registry.lookup(request_type_id)
+    request_action = request_type.available_actions[action_id]
+    request_status = member["request"]["status"]
+    return _can_execute(request_action, request_status)
+
+
+class MemberRequestActionEndpointLink(EndpointLink):
+    """EndpointLink for the action of a request."""
+
+    def __init__(self):
+        """Constructor."""
+        super().__init__(
+            "requests.execute_action",
+            params=["id", "action"],
+            when=_is_context_action_possible,
+        )
+
+    @staticmethod
+    def vars(record, vars):
+        """Update vars with values used to expand the link."""
+        vars.update({"id": record.request_id})
+
+
+class MemberRequestActionsEndpointLinks:
+    """Renders action links related to the request of the member.
+
+    This is 'EndpointLink-input-interface' compliant, but renders a dict of
+    links. That's why we don't inherit from it directly.
+    """
+
+    def __init__(self):
+        """Constructor."""
+        self._endpoint_link = MemberRequestActionEndpointLink()
+
+    def _available_action_ids_for_member(self, obj, context):
+        """Available request action ids for member.
+
+        Actions are based on the request connected to the member.
+        Action ids returned are strings that can be used to retrieve associated
+        RequestAction object.
+
+        Because we don't have a full request object
+        (notably missing created_by, topic, receiver...), we can't rely on a
+        RequestPermissionPolicy for permission of each action. However, actions links
+        are only shown for invitations and membership requests and only specific ones
+        for each. Knowing there is also no MemberService.read
+        (only search/search_invitations/search_membership_requests contexts), we
+        can embed the logic to determine the available actions here.
+
+        :param obj: api.Member
+        :param context: dict of context variables
+        :return: list<str>
+        """
+        # No request actions for active member or members without request
+        # (members that were added directly)
+        if obj.active or not obj.get("request"):
+            return []
+
+        # Not all requests have a type since Member was created before we started
+        # storing the request type. In the case of a Member missing a type, at this
+        # point we know the Member is inactive, but has a request, so the request must
+        # be an invitation (the assumption existing before storing request type).
+        request_type_id = obj["request"].get("type") or "community-invitation"
+
+        # Get its actions. This is where we shortcut the normal request permission
+        # policy check - which is legitimate.
+        if request_type_id == CommunityInvitation.type_id:
+            return ["cancel"]
+        elif request_type_id == MembershipRequestRequestType.type_id:
+            return ["accept", "decline"]
+        else:
+            return []
+
+    def _action_injected_context(self, context, action_id):
+        """Return a context with action_id injected in it under "action" key.
+
+        This has to be done because the endpoint route expects "action" as a parameter.
+        We use action_id until then because it is more precise and distinct from
+        a RequestAction object.
+        """
+        ctx = context.copy()
+        ctx["action"] = action_id
+        return ctx
+
+    def should_render(self, obj, context):
+        """Only render if any action would render.
+
+        :param obj: api.Member
+        :param context: dict of context variables
+        """
+        return any(
+            self._endpoint_link.should_render(
+                obj, self._action_injected_context(context, action_id)
+            )
+            for action_id in self._available_action_ids_for_member(obj, context)
+        )
+
+    def expand(self, obj, context):
+        """Expand the endpoints.
+
+        :param obj: api.Member
+        :param context: dict of context data
+        """
+        links = {}
+
+        for action in self._available_action_ids_for_member(obj, context):
+            ctx = self._action_injected_context(context, action)
+            if self._endpoint_link.should_render(obj, ctx):
+                links[action] = self._endpoint_link.expand(obj, ctx)
+
+        return links

--- a/invenio_communities/members/services/request.py
+++ b/invenio_communities/members/services/request.py
@@ -32,75 +32,6 @@ def service():
 
 
 #
-# CommunityInvitation: actions and request type
-#
-
-
-#
-# Actions
-#
-# All actions use `system_identity` and not the `identity` param, because
-# the permission check happens at the request service (`execute_action`) level
-# before reaching these components and therefore the check is not needed.
-# These actions will assert the identity is `system identity`, which cannot
-# be obtained as a user.
-class AcceptAction(actions.AcceptAction):
-    """Accept action."""
-
-    def execute(self, identity, uow):
-        """Execute action."""
-        service().accept_invite(system_identity, self.request.id, uow=uow)
-        uow.register(
-            NotificationOp(
-                CommunityInvitationAcceptNotificationBuilder.build(self.request)
-            )
-        )
-        super().execute(identity, uow)
-
-
-class DeclineAction(actions.DeclineAction):
-    """Delete action."""
-
-    def execute(self, identity, uow):
-        """Execute action."""
-        service().decline_invite(system_identity, self.request.id, uow=uow)
-        uow.register(
-            NotificationOp(
-                CommunityInvitationDeclineNotificationBuilder.build(self.request)
-            )
-        )
-        super().execute(identity, uow)
-
-
-class CancelAction(actions.CancelAction):
-    """Cancel action."""
-
-    def execute(self, identity, uow):
-        """Execute action."""
-        service().decline_invite(system_identity, self.request.id, uow=uow)
-        uow.register(
-            NotificationOp(
-                CommunityInvitationCancelNotificationBuilder.build(self.request)
-            )
-        )
-        super().execute(identity, uow)
-
-
-class ExpireAction(actions.ExpireAction):
-    """Expire action."""
-
-    def execute(self, identity, uow):
-        """Execute action."""
-        service().decline_invite(system_identity, self.request.id, uow=uow)
-        uow.register(
-            NotificationOp(
-                CommunityInvitationExpireNotificationBuilder.build(self.request)
-            )
-        )
-        super().execute(identity, uow)
-
-
-#
 # Request
 #
 def is_request_created_by_current_user(obj, vars):
@@ -109,7 +40,7 @@ def is_request_created_by_current_user(obj, vars):
     Because this is called in the context of a RequestType, the received obj
     can be a Request or RequestEvent, so better to trust the vars content.
 
-    :param request: api.Request
+    :param request: api.Request|api.RequestEvent
     :param vars: dict: context variables w/ keys:
         "permission_policy_cls" for api.Request
         "identity"
@@ -158,6 +89,75 @@ def update_vars_for_community_dashboard_request_view(obj, vars):
         pid_value=slug,
         request_pid_value=request.id,
     )
+
+
+#
+# CommunityInvitation: actions and request type
+#
+
+
+#
+# Actions
+#
+# All actions use `system_identity` and not the `identity` param, because
+# the permission check happens at the request service (`execute_action`) level
+# before reaching these components and therefore the check is not needed.
+# These actions will assert the identity is `system identity`, which cannot
+# be obtained as a user.
+class AcceptAction(actions.AcceptAction):
+    """Accept action."""
+
+    def execute(self, identity, uow):
+        """Execute action."""
+        service().accept_member_request(system_identity, self.request.id, uow=uow)
+        uow.register(
+            NotificationOp(
+                CommunityInvitationAcceptNotificationBuilder.build(self.request)
+            )
+        )
+        super().execute(identity, uow)
+
+
+class DeclineAction(actions.DeclineAction):
+    """Delete action."""
+
+    def execute(self, identity, uow):
+        """Execute action."""
+        service().close_member_request(system_identity, self.request.id, uow=uow)
+        uow.register(
+            NotificationOp(
+                CommunityInvitationDeclineNotificationBuilder.build(self.request)
+            )
+        )
+        super().execute(identity, uow)
+
+
+class CancelAction(actions.CancelAction):
+    """Cancel action."""
+
+    def execute(self, identity, uow):
+        """Execute action."""
+        service().close_member_request(system_identity, self.request.id, uow=uow)
+        uow.register(
+            NotificationOp(
+                CommunityInvitationCancelNotificationBuilder.build(self.request)
+            )
+        )
+        super().execute(identity, uow)
+
+
+class ExpireAction(actions.ExpireAction):
+    """Expire action."""
+
+    def execute(self, identity, uow):
+        """Execute action."""
+        service().close_member_request(system_identity, self.request.id, uow=uow)
+        uow.register(
+            NotificationOp(
+                CommunityInvitationExpireNotificationBuilder.build(self.request)
+            )
+        )
+        super().execute(identity, uow)
 
 
 class CommunityInvitation(RequestType):
@@ -212,13 +212,50 @@ class CommunityInvitation(RequestType):
 #
 
 
+class AcceptMembershipRequestAction(actions.AcceptAction):
+    """Accept membership request action."""
+
+    def execute(self, identity, uow):
+        """Execute action."""
+        service().accept_member_request(system_identity, self.request.id, uow=uow)
+        # TODO: notifications for accept
+        # uow.register(
+        #     NotificationOp(
+        #         (
+        #             CommunityMembershipRequestAcceptNotificationBuilder.build(
+        #                 self.request
+        #             )
+        #         )
+        #     )
+        # )
+        super().execute(identity, uow)
+
+
 class CancelMembershipRequestAction(actions.CancelAction):
     """Cancel membership request action."""
 
     def execute(self, identity, uow):
         """Execute action."""
-        service().close_membership_request(system_identity, self.request.id, uow=uow)
+        service().close_member_request(system_identity, self.request.id, uow=uow)
         # TODO: Investigate notifications
+        super().execute(identity, uow)
+
+
+class DeclineMembershipRequestAction(actions.DeclineAction):
+    """Decline action."""
+
+    def execute(self, identity, uow):
+        """Execute action."""
+        service().close_member_request(system_identity, self.request.id, uow=uow)
+        # TODO: Notification for declining
+        # uow.register(
+        #     NotificationOp(
+        #         (
+        #             CommunityMembershipRequestDeclineNotificationBuilder
+        #             .build(self.request)
+        #         )
+        #     )
+        # )
         super().execute(identity, uow)
 
 
@@ -230,8 +267,10 @@ class MembershipRequestRequestType(RequestType):
 
     create_action = "create"
     available_actions = {
+        "accept": AcceptMembershipRequestAction,
         "create": actions.CreateAndSubmitAction,
         "cancel": CancelMembershipRequestAction,
+        "decline": DeclineMembershipRequestAction,
     }
 
     creator_can_be_none = False

--- a/invenio_communities/members/services/request.py
+++ b/invenio_communities/members/services/request.py
@@ -279,6 +279,16 @@ class MembershipRequestRequestType(RequestType):
     allowed_receiver_ref_types = ["community"]
     allowed_topic_ref_types = ["community"]
 
+    # This lists the roles that are associated wtih a community entity in the context
+    # of request action permissions. e.g., Receiver() (for a community receiver) will
+    # map to users with the owner/manager roles
+    needs_context = {
+        "community_roles": [
+            "owner",
+            "manager",
+        ]
+    }
+
     links_item = {
         # This EndpointLink selection logic is better than existing logic for
         # other RequestTypes' self_html, bc it points to right place depending

--- a/invenio_communities/members/services/service.py
+++ b/invenio_communities/members/services/service.py
@@ -441,8 +441,8 @@ class MemberService(RecordService):
     def update(self, identity, community_id, data, uow=None, refresh=False):
         """Bulk update.
 
-        Used to update both active members and active invitations. Archived
-        invitations cannot be updated.
+        Used to update both active members and non-archived invitations + membership
+        requests. Archived invitations/membership-requests cannot be updated.
         """
         community = self.community_cls.get_record(community_id)
 
@@ -647,7 +647,57 @@ class MemberService(RecordService):
 
         return True
 
-    # Invitation
+    # Member requests
+
+    @unit_of_work()
+    def accept_member_request(self, identity, request_id, uow=None):
+        """Accept member request (invitation or membership request)."""
+        # Permissions are checked on the request action
+        assert identity == system_identity
+        member = self.record_cls.get_member_by_request(request_id)
+        assert member.active is False
+        archived_member_request = self.archive_cls.create_from_member(member)
+        member.active = True
+        # Run components
+        self.run_components(
+            "accept_member_request",
+            identity,
+            record=member,
+            errors=None,
+            uow=uow,
+        )
+
+        uow.register(RecordCommitOp(member, indexer=self.indexer, index_refresh=True))
+        uow.register(
+            RecordCommitOp(
+                archived_member_request,
+                indexer=self.archive_indexer,
+                index_refresh=True,
+            )
+        )
+
+    @unit_of_work()
+    def close_member_request(self, identity, request_id, uow=None):
+        """Close member request (invitation or membership request).
+
+        Used when cancelling, declining, or expiring.
+        """
+        # Permissions are checked on the request action
+        assert identity == system_identity
+        member = self.record_cls.get_member_by_request(request_id)
+        assert member.active is False
+        archived_member_request = self.archive_cls.create_from_member(member)
+        uow.register(RecordDeleteOp(member, indexer=self.indexer, force=True))
+        uow.register(
+            RecordCommitOp(archived_member_request, indexer=self.archive_indexer)
+        )
+        uow.register(
+            IndexRefreshOp(
+                indexer=self.indexer,
+                index=ArchivedMemberRequest.index,
+            )
+        )
+
     # Member requests - Invitation
 
     def _invite_factory(
@@ -798,52 +848,6 @@ class MemberService(RecordService):
             **kwargs,
         )
 
-    @unit_of_work()
-    def accept_invite(self, identity, request_id, uow=None):
-        """Accept an invitation."""
-        # Permissions are checked on the request action
-        assert identity == system_identity
-        member = self.record_cls.get_member_by_request(request_id)
-        assert member.active is False
-        archived_member_request = self.archive_cls.create_from_member(member)
-        member.active = True
-        # TODO: recompute permissions for member.
-        # Run components
-        self.run_components(
-            "accept_invite",
-            identity,
-            record=member,
-            errors=None,
-            uow=uow,
-        )
-
-        uow.register(RecordCommitOp(member, indexer=self.indexer))
-        uow.register(
-            RecordCommitOp(archived_member_request, indexer=self.archive_indexer)
-        )
-        uow.register(IndexRefreshOp(indexer=self.indexer))
-
-    @unit_of_work()
-    def decline_invite(self, identity, request_id, uow=None):
-        """Decline an invitation."""
-        # Permissions are checked on the request action
-        assert identity == system_identity
-        member = self.record_cls.get_member_by_request(request_id)
-        assert member.active is False
-        archived_member_request = self.archive_cls.create_from_member(member)
-        uow.register(RecordDeleteOp(member, indexer=self.indexer, force=True))
-        uow.register(
-            RecordCommitOp(archived_member_request, indexer=self.archive_indexer)
-        )
-        uow.register(
-            IndexRefreshOp(
-                # need to use an indexer with a diff index
-                # no access to invitations indexer
-                indexer=self.indexer,
-                index=ArchivedMemberRequest.index,
-            )
-        )
-
     # Request membership
     @unit_of_work()
     def request_membership(self, identity, community_id, data, uow=None):
@@ -928,12 +932,6 @@ class MemberService(RecordService):
         # Has to return the request so that frontend can redirect to it
         return request_item
 
-    @unit_of_work()
-    def update_membership_request(self, identity, community_id, data, uow=None):
-        """Update membership request."""
-        # TODO: Implement me
-        pass
-
     def search_membership_requests(
         self, identity, community_id, params=None, search_preference=None, **kwargs
     ):
@@ -969,28 +967,6 @@ class MemberService(RecordService):
             ),
             **kwargs,
         )
-
-    @unit_of_work()
-    def accept_membership_request(self, identity, request_id, uow=None):
-        """Accept membership request."""
-        # TODO: Implement me
-        pass
-
-    @unit_of_work()
-    def close_membership_request(self, identity, request_id, uow=None):
-        """Close membership request.
-
-        Used for cancelling, declining, or expiring a membership request.
-
-        For now we just delete the "fake" member that was created in
-        request_membership. TODO: explore alternatives/ramifications at a
-        later point.
-        """
-        # Permissions are checked on the request action
-        assert identity == system_identity
-        member = self.record_cls.get_member_by_request(request_id)
-        assert member.active is False
-        uow.register(RecordDeleteOp(member, indexer=self.indexer, force=True))
 
     def get_request_id_of_pending_member(self, identity, community_id):
         """

--- a/tests/members/test_members_components.py
+++ b/tests/members/test_members_components.py
@@ -24,7 +24,7 @@ def test_accept_invite_cache_clear(
     community_roles = current_identities_cache.get(cache_key)
     assert len(community_roles) == 0
 
-    # cached entry should be cleared on accept_invite
+    # cached entry should be cleared on accept_member_request
     requests_service.execute_action(invite_user.identity, invite_request_id, "accept")
     community_roles = current_identities_cache.get(cache_key)
     assert community_roles is None

--- a/tests/members/test_members_resource.py
+++ b/tests/members/test_members_resource.py
@@ -380,10 +380,15 @@ def test_search_invitations(
     # hits > hit > permissions
     assert hit["permissions"]["can_update_role"] is True
     assert hit["permissions"]["can_cancel"] is True
+    # hits > hit > links
+    expected_links = {
+        "actions": {
+            "cancel": f"https://127.0.0.1:5000/api/requests/{request_id}/actions/cancel",  # noqa
+        },
+    }
+    assert expected_links == hit["links"]
 
 
-# TODO: member serialization/links
-# TODO: request serialization/links
 # TODO: community member can see info
 # TODO: community non-member can't see info
 # TODO: facet by role, facet by visibility, define sorts.
@@ -480,24 +485,45 @@ def test_get_search_membership_requests(
     # TODO: Test when expiration is implemented
     # assert "expires_at" in hit["request"]
     # assert hit["request"]["expires_at"] is not None
-    # TODO: Test when actions are implemented
     # hits > hit > links
-    # request_id = hit["request"]["id"]
-    # expected_links = {
-    #     "actions": {
-    #         "accept": f"https://127.0.0.1:5000/api/requests/{request_id}/actions/accept",  # noqa
-    #         "decline": f"https://127.0.0.1:5000/api/requests/{request_id}/actions/decline",  # noqa
-    #     },
-    # }
-    # assert expected_links == hit["links"]
+    request_id = hit["request"]["id"]
+    expected_links = {
+        "actions": {
+            "accept": f"https://127.0.0.1:5000/api/requests/{request_id}/actions/accept",  # noqa
+            "decline": f"https://127.0.0.1:5000/api/requests/{request_id}/actions/decline",  # noqa
+        },
+    }
+    assert expected_links == hit["links"]
 
 
 def test_put_update_membership_requests(
-    client, headers, community_id, owner, new_user_data, db
+    client,
+    community_open_to_membership_requests,
+    create_user,
+    db,
+    headers,
+    owner,
 ):
-    # update membership request
-    # TODO: Implement me!
-    assert True
+    user = create_user({"email": "user_foo@example.org", "username": "user_foo"})
+    client = user.login(client)
+    community_id = str(community_open_to_membership_requests._record.id)
+    r = client.post(
+        f"/communities/{community_id}/membership-requests",
+        headers=headers,
+        json={"message": "Can I join the club?"},
+    )
+
+    # Update the membership request
+    client = owner.login(client, logout_first=True)
+    r = client.put(
+        f"/communities/{community_id}/membership-requests",
+        headers=headers,
+        json={
+            "members": [{"type": "user", "id": str(user.id)}],
+            "role": "curator",
+        },
+    )
+    assert r.status_code == 204
 
 
 def test_error_handling_for_membership_requests(

--- a/tests/members/test_members_services.py
+++ b/tests/members/test_members_services.py
@@ -18,7 +18,7 @@ from invenio_requests.records.api import Request, RequestEvent
 from marshmallow import ValidationError
 
 from invenio_communities.members.errors import AlreadyMemberError, InvalidMemberError
-from invenio_communities.members.records.api import ArchivedInvitation, Member
+from invenio_communities.members.records.api import Member
 from invenio_communities.proxies import current_identities_cache
 
 
@@ -499,16 +499,13 @@ def test_invite_accept_flow(
 ):
     """Invite a user."""
     # Accept request
-    request = requests_service.execute_action(
-        invite_user.identity, invite_request_id, "accept"
-    ).to_dict()
+    requests_service.execute_action(invite_user.identity, invite_request_id, "accept")
 
     # See new member in list
     res = member_service.search(owner.identity, community._record.id)
     assert res.to_dict()["hits"]["total"] == 2
 
     # See invitation in archived list
-    ArchivedInvitation.index.refresh()
     res = member_service.search_invitations(owner.identity, community._record.id)
     assert res.to_dict()["hits"]["total"] == 1
 
@@ -1289,6 +1286,99 @@ def test_cancel_membership_request(
         community._record.id,
         {"message": "Oops didn't mean to cancel. Oh well, I will request again."},
     )
+
+
+def test_decline_membership_request(
+    clean_index,
+    community_open_to_membership_requests,
+    db,
+    membership_request,
+    member_service,
+    owner,
+    requests_service,
+):
+    community = community_open_to_membership_requests
+    # pre-condition: only owner
+    result = member_service.search(owner.identity, community._record.id).to_dict()
+    assert result["hits"]["total"] == 1
+
+    requests_service.execute_action(owner.identity, membership_request.id, "decline")
+
+    # Only owner in list
+    Member.index.refresh()
+    result = member_service.search(owner.identity, community._record.id).to_dict()
+    assert result["hits"]["total"] == 1
+    # Has been archived
+    result = member_service.search_membership_requests(
+        owner.identity, community._record.id
+    ).to_dict()
+    assert result["hits"]["total"] == 1
+    hit = result["hits"]["hits"][0]
+    assert "declined" == hit["request"]["status"]
+    assert hit["request"]["is_open"] is False
+
+
+def test_accept_membership_request(
+    clean_index,
+    community_open_to_membership_requests,
+    db,
+    membership_request,
+    member_service,
+    owner,
+    requests_service,
+):
+    community = community_open_to_membership_requests
+    # pre-condition: only owner
+    result = member_service.search(owner.identity, community._record.id).to_dict()
+    assert result["hits"]["total"] == 1
+
+    requests_service.execute_action(owner.identity, membership_request.id, "accept")
+
+    # By adding index_refresh to accept_member_request, we don't need those
+    # refresh() calls.
+    # post-conditions:
+    # 1) 2 members: the owner + requester
+    result = member_service.search(owner.identity, community._record.id).to_dict()
+    assert 2 == result["hits"]["total"]
+
+    # 2) 1 member request, the accepted one
+    result = member_service.search_membership_requests(
+        owner.identity, community._record.id
+    ).to_dict()
+    assert 1 == result["hits"]["total"]
+    hit = result["hits"]["hits"][0]
+    assert "accepted" == hit["request"]["status"]
+    assert hit["request"]["is_open"] is False
+
+
+def test_update_membership_request_role(
+    clean_index,
+    community_open_to_membership_requests,
+    create_user,
+    db,
+    member_service,
+    owner,
+):
+    community = community_open_to_membership_requests
+    # Create membership request
+    user = create_user()
+    community = community_open_to_membership_requests
+    membership_request = member_service.request_membership(
+        user.identity,
+        community._record.id,
+        data={"message": "Can I join the club?"},
+    )
+    data = {
+        "members": [{"type": "user", "id": str(user.id)}],
+        "role": "manager",
+    }
+
+    # Case: owner can update role of requester
+    member_service.update(owner.identity, community._record.id, data)
+
+    # Case: requester cannot update its role
+    with pytest.raises(PermissionDeniedError):
+        member_service.update(user.identity, community._record.id, data)
 
 
 #

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -14,9 +14,11 @@ CommunityPermissionPolicy is defined at the top-level, the test are defined ther
 
 import copy
 
+import pytest
 from flask_principal import Identity
 
 from invenio_communities.generators import CommunityRoleNeed
+from invenio_communities.members import Member
 from invenio_communities.permissions import CommunityPermissionPolicy
 
 
@@ -145,3 +147,68 @@ def test_can_search_request_membership(
     assert not policy(action=action, record=community_open_record).allows(identity)
     identity.provides = identity_orig.provides.union({needs["reader"]})
     assert not policy(action=action, record=community_open_record).allows(identity)
+
+
+@pytest.fixture()
+def membership_request_member(
+    community_open_to_membership_requests,
+    create_user,
+    db,
+    member_service,
+    search_clear,
+):
+    user = create_user(
+        data={
+            "email": "membership-requester@example.org",
+            "username": "membership-requester",
+        }
+    )
+    request = member_service.request_membership(
+        user.identity,
+        community_open_to_membership_requests._record.id,
+        data={"message": "Can I join the club?"},
+    )
+    return Member.get_member_by_request(request.id)
+
+
+@pytest.mark.parametrize(
+    "actor,initial_role,new_role,allowed_or_not",
+    [
+        ("owner", "reader", "owner", True),
+        ("owner", "owner", "reader", True),
+        ("manager", "reader", "manager", True),
+        ("manager", "manager", "reader", True),
+        ("reader", "reader", "curator", False),
+        ("curator", "reader", "curator", False),
+        ("manager", "reader", "owner", False),
+    ],
+)
+def test_can_update_membership_request_role(
+    actor,
+    initial_role,
+    new_role,
+    allowed_or_not,
+    app,
+    community_open_to_membership_requests,
+    create_user,
+    member_service,
+    membership_request_member,
+):
+    policy = CommunityPermissionPolicy
+    community_open_record = community_open_to_membership_requests._record
+    user = create_user()
+    identity_actor = Identity(user.id)
+    identity_actor.provides |= {
+        CommunityRoleNeed(value=str(community_open_record.id), role=actor)
+    }
+    membership_request_member.role = initial_role
+
+    assert (
+        policy(
+            action="members_update",
+            record=community_open_record,
+            member=membership_request_member,
+            role=new_role,
+        ).allows(identity_actor)
+        is allowed_or_not
+    )

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -16,6 +16,9 @@ import copy
 
 import pytest
 from flask_principal import Identity
+from invenio_requests.services.permissions import (
+    PermissionPolicy as RequestPermissionPolicy,
+)
 
 from invenio_communities.generators import CommunityRoleNeed
 from invenio_communities.members import Member
@@ -209,6 +212,65 @@ def test_can_update_membership_request_role(
             record=community_open_record,
             member=membership_request_member,
             role=new_role,
+        ).allows(identity_actor)
+        is allowed_or_not
+    )
+
+
+@pytest.mark.parametrize(
+    "action,role,allowed_or_not",
+    [
+        # Accept
+        ("accept", "manager", True),  # stand in for manager and owner
+        ("accept", "curator", False),  # stand in for any other member
+        ("accept", "requester", False),
+        # Decline
+        ("decline", "owner", True),
+        ("decline", "curator", False),
+        ("decline", "requester", False),
+        # Cancel
+        ("cancel", "manager", False),
+        ("cancel", "curator", False),
+        ("cancel", "requester", True),
+        # Expire
+        ("expire", "manager", False),
+        ("expire", "curator", False),
+        ("expire", "requester", False),
+    ],
+)
+def test_can_perform_actions_on_membership_request(
+    # parameters
+    action,
+    allowed_or_not,
+    role,
+    # fixtures
+    community_open_to_membership_requests,
+    create_user,
+    member_service,
+):
+    # Membership request
+    community = community_open_to_membership_requests
+    requester_user = create_user()
+    request = member_service.request_membership(
+        requester_user.identity,
+        community._record.id,
+        data={"message": "Can I join the club?"},
+    )
+
+    # Identity of actor
+    if role == "requester":
+        identity_actor = requester_user.identity
+    else:
+        actor_user = create_user({"username": "actor", "email": "actor@example.org"})
+        identity_actor = actor_user.identity
+        identity_actor.provides |= {
+            CommunityRoleNeed(value=str(community.id), role=role)
+        }
+
+    assert (
+        RequestPermissionPolicy(
+            action=f"action_{action}",
+            request=request._record,
         ).allows(identity_actor)
         is allowed_or_not
     )


### PR DESCRIPTION
This PR is # 4 in a series of PRs to revive and merge the "Request to join a community as a user" feature. Draft RFC here: https://github.com/inveniosoftware/rfcs/pull/111 .

This PR covers the part of the feature that deals with backend interactions with request memberships. Specifically: actions (accept, decline) on members (membership requests and fix for invitations), links for these actions and role update of membership requests.

**Out of bounds/future PRs**: any frontend aspect and any notifications. 

**Current commits**
- **feat(mshp-req): accept,decline,cancel,upate role of membership requests**
