### PR TITLE
i18n: replace .format() with %-style

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,7 @@
     This file is part of Invenio.
     Copyright (C) 2016-2025 CERN.
     Copyright (C) 2024-2026 Graz University of Technology.
+    Copyright (C) 2026 KTH Royal Institute of Technology.
 
     Invenio is free software; you can redistribute it and/or modify it
     under the terms of the MIT License; see LICENSE file for more details.
@@ -9,6 +10,10 @@
 
 Changes
 =======
+
+Version v26.0.1 (released 2026-04-20)
+
+- i18n: fix strings formatting in schema and error messages
 
 Version v26.0.0 (released 2026-04-02)
 

--- a/invenio_communities/__init__.py
+++ b/invenio_communities/__init__.py
@@ -12,6 +12,6 @@
 from .ext import InvenioCommunities
 from .proxies import current_communities
 
-__version__ = "26.0.0"
+__version__ = "26.0.1"
 
 __all__ = ("InvenioCommunities", "current_communities")

--- a/invenio_communities/communities/schema.py
+++ b/invenio_communities/communities/schema.py
@@ -3,7 +3,7 @@
 # This file is part of Invenio.
 # Copyright (C) 2016-2024 CERN.
 # Copyright (C) 2023-2025 Graz University of Technology.
-# Copyright (C) 2024 KTH Royal Institute of Technology.
+# Copyright (C) 2024-2026 KTH Royal Institute of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -51,9 +51,7 @@ def _not_blank(**kwargs):
     """Returns a non-blank validation rule."""
     max_ = kwargs.get("max", "")
     return validate.Length(
-        error=_(
-            "Field cannot be blank or longer than {max_} characters.".format(max_=max_)
-        ),
+        error=_("Field cannot be blank or longer than %(max)s characters.", max=max_),
         min=1,
         **kwargs,
     )
@@ -62,7 +60,7 @@ def _not_blank(**kwargs):
 def no_longer_than(max, **kwargs):
     """Returns a character limit validation rule."""
     return validate.Length(
-        error=_("Field cannot be longer than {max} characters.".format(max=max)),
+        error=_("Field cannot be longer than %(max)s characters.", max=max),
         max=max,
         **kwargs,
     )

--- a/invenio_communities/errors.py
+++ b/invenio_communities/errors.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2022 Northwestern University.
+# Copyright (C) 2026 KTH Royal Institute of Technology.
 #
 # Invenio-Communities is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more details.
@@ -24,9 +25,8 @@ class CommunityFeaturedEntryDoesNotExistError(CommunityError):
         """Initialise error."""
         super().__init__(
             _(
-                "A featured community entry with {q} does not exist.".format(
-                    q=query_arguments
-                )
+                "A featured community entry with %(q)s does not exist.",
+                q=query_arguments,
             )
         )
 
@@ -48,12 +48,12 @@ class LogoSizeLimitError(CommunityError):
         file_size_value, file_size_unit = humanize_byte_size(file_size)
         super().__init__(
             _(
-                "Logo size limit exceeded. Limit: {limit_value} {limit_unit} Given: {file_size_value} {file_size_unit}".format(
-                    limit_value=limit_value,
-                    limit_unit=limit_unit,
-                    file_size_value=file_size_value,
-                    file_size_unit=file_size_unit,
-                )
+                "Logo size limit exceeded. Limit: %(limit_value)s %(limit_unit)s "
+                "Given: %(file_size_value)s %(file_size_unit)s",
+                limit_value=limit_value,
+                limit_unit=limit_unit,
+                file_size_value=file_size_value,
+                file_size_unit=file_size_unit,
             )
         )
 


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

> AI use disclosure: Most of this PR was generated with Codex, with additional guidance, cleanup, and adjustments to match the existing codebase style.

* Using .format() inside lazy_gettext creates a separate translation entry for each unique argument value.
* Switch to %-style keyword arguments so only a single translation string is registered per message.
* closes: https://github.com/inveniosoftware/invenio-communities/issues/1370



### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
