### PR TITLE
fix: correct untranslatable string interpolation

### DIFF
--- a/invenio_communities/communities/schema.py
+++ b/invenio_communities/communities/schema.py
@@ -51,9 +51,7 @@ def _not_blank(**kwargs):
     """Returns a non-blank validation rule."""
     max_ = kwargs.get("max", "")
     return validate.Length(
-        error=_(
-            "Field cannot be blank or longer than {max_} characters.".format(max_=max_)
-        ),
+        error=_("Field cannot be blank or longer than %(max_)s characters.", max_=max_),
         min=1,
         **kwargs,
     )
@@ -62,7 +60,7 @@ def _not_blank(**kwargs):
 def no_longer_than(max, **kwargs):
     """Returns a character limit validation rule."""
     return validate.Length(
-        error=_("Field cannot be longer than {max} characters.".format(max=max)),
+        error=_("Field cannot be longer than %(max)s characters.", max_=max_),
         max=max,
         **kwargs,
     )

--- a/invenio_communities/communities/schema.py
+++ b/invenio_communities/communities/schema.py
@@ -60,7 +60,7 @@ def _not_blank(**kwargs):
 def no_longer_than(max, **kwargs):
     """Returns a character limit validation rule."""
     return validate.Length(
-        error=_("Field cannot be longer than %(max)s characters.", max_=max_),
+        error=_("Field cannot be longer than %(max)s characters.", max_=max),
         max=max,
         **kwargs,
     )


### PR DESCRIPTION
### Description

This fixes the problem described in https://github.com/inveniosoftware/invenio-communities/issues/1370


### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).