### PR TITLE
fix: custom fields serialization

### DIFF
--- a/invenio_communities/assets/semantic-ui/js/invenio_communities/settings/profile/CustomFieldSerializer.js
+++ b/invenio_communities/assets/semantic-ui/js/invenio_communities/settings/profile/CustomFieldSerializer.js
@@ -52,9 +52,9 @@ export class CustomFieldSerializer {
       if (isVocabulary && value?.id) {
         return value.id;
       }
-      // Add __key if i is passed i.e is an array. This is needed because of ArrayField
-      // internal implementation
-      if (i) value.__key = i;
+      // only assign __key when we're iterating an array (Number.isInteger(i)) and the element is a plain object (not a string or other primitive).
+      if (Number.isInteger(i) && typeof value === "object" && value !== null)
+        value.__key = i;
       return value;
     };
     const _record = _cloneDeep(record);


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

Custom field serializer unselectively treats all arrays as array fields and tries to use __key key. However, in reality you can have a dropdown with multiple options, which is just a string of arrays. Then it tries to add __key to a string and the app crashes and your communities settings page is no longer accessible for this community. 

<img width="721" height="243" alt="image" src="https://github.com/user-attachments/assets/10e059cd-a399-41d3-ab7c-8b5de7f3a29f" />

This fix addresses this problem. Please let us know if it would be OK to merge.