### PR TITLE
request membership part 5 frontend community 2026 04 30

### DIFF
--- a/invenio_communities/assets/semantic-ui/js/invenio_communities/api/membershipRequests/MembershipRequestsContextProvider.js
+++ b/invenio_communities/assets/semantic-ui/js/invenio_communities/api/membershipRequests/MembershipRequestsContextProvider.js
@@ -1,0 +1,34 @@
+// This file is part of Invenio-communities
+//
+// Copyright (C) 2026 Northwestern University.
+//
+// Invenio-communities is free software; you can redistribute it and/or modify it
+// under the terms of the MIT License; see LICENSE file for more details.
+
+import { CommunityMembershipRequestsApi } from "./api";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+
+export const MembershipRequestsContext = React.createContext({ api: undefined });
+
+export class MembershipRequestsContextProvider extends Component {
+  constructor(props) {
+    super(props);
+    const { community } = props;
+    this.apiClient = new CommunityMembershipRequestsApi(community);
+  }
+
+  render() {
+    const { children } = this.props;
+    return (
+      <MembershipRequestsContext.Provider value={{ api: this.apiClient }}>
+        {children}
+      </MembershipRequestsContext.Provider>
+    );
+  }
+}
+
+MembershipRequestsContextProvider.propTypes = {
+  community: PropTypes.object.isRequired,
+  children: PropTypes.node.isRequired,
+};

--- a/invenio_communities/assets/semantic-ui/js/invenio_communities/api/membershipRequests/api.js
+++ b/invenio_communities/assets/semantic-ui/js/invenio_communities/api/membershipRequests/api.js
@@ -1,12 +1,13 @@
 // This file is part of Invenio-communities
 // Copyright (C) 2022 CERN.
-// Copyright (C) 2024 Northwestern University.
+// Copyright (C) 2024-2026 Northwestern University.
 //
 // Invenio-communities is free software; you can redistribute it and/or modify it
 // under the terms of the MIT License; see LICENSE file for more details.
 
 import { CommunityLinksExtractor } from "../CommunityLinksExtractor";
 import { http } from "react-invenio-forms";
+import { bulkMembersSerializer } from "../serializers";
 
 /**
  * API Client for community membership requests.
@@ -22,5 +23,26 @@ export class CommunityMembershipRequestsApi {
 
   requestMembership = async (payload) => {
     return await http.post(this.linksExtractor.url("membership_requests"), payload);
+  };
+
+  /**
+   * Makes a PUT call to resource endpoint to update role of member.
+   *
+   * That endpoint accepts a bulk update format, so we serialize accordingly.
+   *
+   * This is an assignment rather than function definition for ease of passing
+   * as callback.
+   *
+   * @param {object} member - member field of search result on Members JSON API
+   * @param {string} role - new community role id
+   * @returns {axios Response} -
+   *
+   */
+  updateRole = async (member, role) => {
+    const payload = {
+      members: bulkMembersSerializer([member]),
+      role: role,
+    };
+    return await http.put(this.linksExtractor.url("membership_requests"), payload);
   };
 }

--- a/invenio_communities/assets/semantic-ui/js/invenio_communities/members/Filters.js
+++ b/invenio_communities/assets/semantic-ui/js/invenio_communities/members/Filters.js
@@ -55,6 +55,12 @@ export class Filters {
     return { ...rolesFilters, ...visibilityFilters };
   }
 
+  getMembershipRequestsFilters() {
+    const rolesFilters = this.getRoles();
+    const statusFilters = this.getStatus();
+    return { ...rolesFilters, ...statusFilters };
+  }
+
   getHumanReadableVisibility(value) {
     return value === "true" ? i18next.t("Public") : i18next.t("Hidden");
   }

--- a/invenio_communities/assets/semantic-ui/js/invenio_communities/members/invitations/InvitationResultItem.js
+++ b/invenio_communities/assets/semantic-ui/js/invenio_communities/members/invitations/InvitationResultItem.js
@@ -1,23 +1,23 @@
 /*
  * This file is part of Invenio.
  * Copyright (C) 2022 CERN.
+ * Copyright (C) 2026 Northwestern University.
  *
  * Invenio is free software; you can redistribute it and/or modify it
  * under the terms of the MIT License; see LICENSE file for more details.
  */
 
+import { RequestActionController } from "@js/invenio_requests/request/actions/RequestActionController";
+import RequestStatus from "@js/invenio_requests/request/RequestStatus";
 import { i18next } from "@translations/invenio_communities/i18next";
-import { DateTime } from "luxon";
 import PropTypes from "prop-types";
 import React, { Component } from "react";
 import { Image } from "react-invenio-forms";
 import { Container, Grid, Item, Table } from "semantic-ui-react";
+
 import { InvitationsContext } from "../../api/invitations/InvitationsContextProvider";
 import { RoleDropdown } from "../components/dropdowns";
-import RequestStatus from "@js/invenio_requests/request/RequestStatus";
-
-const formattedTime = (expiresAt) =>
-  DateTime.fromISO(expiresAt).setLocale(i18next.language).toRelative();
+import { buildRequestFromMember, formattedTime } from "../utils";
 
 export class InvitationResultItem extends Component {
   constructor(props) {
@@ -38,13 +38,17 @@ export class InvitationResultItem extends Component {
       config: { rolesCanInvite },
       community,
     } = this.props;
+
     const {
-      invitation: { member, request },
+      invitation: { member },
       invitation,
     } = this.state;
+
+    const request = buildRequestFromMember(invitation, ["cancel"]);
     const { api: invitationsApi } = this.context;
     const rolesCanInviteByType = rolesCanInvite[member.type];
     const memberInvitationExpiration = formattedTime(request.expires_at);
+
     return (
       <Table.Row className="community-member-item">
         <Table.Cell>
@@ -90,11 +94,12 @@ export class InvitationResultItem extends Component {
         </Table.Cell>
         <Table.Cell>
           <Container fluid textAlign="right">
-            {/* TODO uncomment when links available in the request resource subschema */}
-            {/*<RequestActionController*/}
-            {/*  request={request }*/}
-            {/*  actionSuccessCallback={this.updateInvitation}*/}
-            {/*>*/}
+            <RequestActionController
+              request={request}
+              actionSuccessCallback={() => {
+                window.location.reload();
+              }}
+            />
             {/*<ActionButtons request={invitation} />*/}
             {/*</RequestActionController>*/}
           </Container>

--- a/invenio_communities/assets/semantic-ui/js/invenio_communities/members/invitations/InvitationResultItem.js
+++ b/invenio_communities/assets/semantic-ui/js/invenio_communities/members/invitations/InvitationResultItem.js
@@ -46,8 +46,9 @@ export class InvitationResultItem extends Component {
 
     const request = buildRequestFromMember(invitation, ["cancel"]);
     const { api: invitationsApi } = this.context;
-    const rolesCanInviteByType = rolesCanInvite[member.type];
+    const roles = rolesCanInvite[member.type];
     const memberInvitationExpiration = formattedTime(request.expires_at);
+    const linkToRequest = invitation.links.self_html;
 
     return (
       <Table.Row className="community-member-item">
@@ -58,9 +59,7 @@ export class InvitationResultItem extends Component {
                 <Image src={member.avatar} avatar circular className="mr-10" />
                 <Item.Content>
                   <Item.Header size="small" as="b">
-                    <a href={`/communities/${community.slug}/requests/${request.id}`}>
-                      {member.name}
-                    </a>
+                    <a href={linkToRequest}>{member.name}</a>
                   </Item.Header>
                   {member.description && (
                     <Item.Meta>
@@ -83,7 +82,7 @@ export class InvitationResultItem extends Component {
         </Table.Cell>
         <Table.Cell data-label={i18next.t("Role")}>
           <RoleDropdown
-            roles={rolesCanInviteByType}
+            roles={roles}
             successCallback={this.updateInvitation}
             action={invitationsApi.updateRole}
             disabled={!invitation.permissions.can_update_role}
@@ -100,8 +99,6 @@ export class InvitationResultItem extends Component {
                 window.location.reload();
               }}
             />
-            {/*<ActionButtons request={invitation} />*/}
-            {/*</RequestActionController>*/}
           </Container>
         </Table.Cell>
       </Table.Row>

--- a/invenio_communities/assets/semantic-ui/js/invenio_communities/members/invitations/InvitationsEmptyResults.js
+++ b/invenio_communities/assets/semantic-ui/js/invenio_communities/members/invitations/InvitationsEmptyResults.js
@@ -34,7 +34,7 @@ class InvitationsEmptyResultsCmp extends Component {
         <Segment placeholder textAlign="center">
           <Header icon>
             <Icon name="search" />
-            {i18next.t("No matching members found.")}
+            {i18next.t("No matching invitations found.")}
           </Header>
           {queryString && (
             <p>

--- a/invenio_communities/assets/semantic-ui/js/invenio_communities/members/invitations/index.js
+++ b/invenio_communities/assets/semantic-ui/js/invenio_communities/members/invitations/index.js
@@ -9,11 +9,12 @@
 import { createSearchAppInit } from "@js/invenio_search_ui";
 import { parametrize, overrideStore } from "react-overridable";
 import { DropdownSort } from "@js/invenio_search_ui/components";
+import { i18next } from "@translations/invenio_communities/i18next";
 import { InvitationsContextProvider as ContextProvider } from "../../api/invitations/InvitationsContextProvider";
 import { InvitationResultItem } from "./InvitationResultItem";
 import { InvitationsResults } from "./InvitationsResults";
 import { InvitationsResultsContainer } from "./InvitationsResultsContainer";
-import { InvitationsSearchBarElement } from "./InvitationsSearchBarElement";
+import { MemberRequestsSearchBarElement } from "../member_requests/MemberRequestsSearchBarElement";
 import { InvitationsSearchLayout } from "./InvitationsSearchLayout";
 import { InvitationsEmptyResults } from "./InvitationsEmptyResults";
 import {
@@ -47,6 +48,11 @@ const InvitationsSearchLayoutWithConfig = parametrize(InvitationsSearchLayout, {
   permissions: permissions,
   groupsEnabled: groupsEnabled,
   appName: appName,
+});
+
+const InvitationsSearchBarElement = parametrize(MemberRequestsSearchBarElement, {
+  className: "invitations-searchbar",
+  placeholder: i18next.t("Search in invitations..."),
 });
 
 const InvitationsContextProvider = parametrize(ContextProvider, {

--- a/invenio_communities/assets/semantic-ui/js/invenio_communities/members/invitations/index.js
+++ b/invenio_communities/assets/semantic-ui/js/invenio_communities/members/invitations/index.js
@@ -6,15 +6,19 @@
  * under the terms of the MIT License; see LICENSE file for more details.
  */
 
+import { RequestCancelButton } from "@js/invenio_requests/components/Buttons";
+import { RequestCancelModalTrigger } from "@js/invenio_requests/components/ModalTriggers";
 import { createSearchAppInit } from "@js/invenio_search_ui";
-import { parametrize, overrideStore } from "react-overridable";
 import { DropdownSort } from "@js/invenio_search_ui/components";
 import { i18next } from "@translations/invenio_communities/i18next";
+import React from "react";
+import { parametrize, overrideStore } from "react-overridable";
+
 import { InvitationsContextProvider as ContextProvider } from "../../api/invitations/InvitationsContextProvider";
+import { MemberRequestsSearchBarElement } from "../member_requests/MemberRequestsSearchBarElement";
 import { InvitationResultItem } from "./InvitationResultItem";
 import { InvitationsResults } from "./InvitationsResults";
 import { InvitationsResultsContainer } from "./InvitationsResultsContainer";
-import { MemberRequestsSearchBarElement } from "../member_requests/MemberRequestsSearchBarElement";
 import { InvitationsSearchLayout } from "./InvitationsSearchLayout";
 import { InvitationsEmptyResults } from "./InvitationsEmptyResults";
 import {
@@ -65,6 +69,14 @@ const InvitationsResultsContainerWithConfig = parametrize(InvitationsResultsCont
   groupsEnabled: groupsEnabled,
 });
 
+const InvitationsRequestActionModalCancelTitle = (props) => {
+  return i18next.t("cancel invitation");
+};
+
+const InvitationsRequestCancelButton = parametrize(RequestCancelButton, {
+  content: i18next.t("Cancel invitation"),
+});
+
 const InvitationsEmptyResultsWithCommunity = parametrize(InvitationsEmptyResults, {
   community: community,
   groupsEnabled: groupsEnabled,
@@ -79,12 +91,15 @@ const defaultComponents = {
   [`${appName}.SearchApp.results`]: InvitationsResults,
   [`${appName}.ResultsList.container`]: InvitationsResultsContainerWithConfig,
   [`${appName}.Sort.element`]: DropdownSort,
-  [`RequestStatus.layout.submitted`]: SubmitStatus,
-  [`RequestStatus.layout.deleted`]: DeleteStatus,
-  [`RequestStatus.layout.accepted`]: AcceptStatus,
-  [`RequestStatus.layout.declined`]: DeclineStatus,
-  [`RequestStatus.layout.cancelled`]: CancelStatus,
-  [`RequestStatus.layout.expired`]: ExpireStatus,
+  "RequestActionModalTrigger.cancel": RequestCancelModalTrigger,
+  "RequestActionModal.title.cancel": InvitationsRequestActionModalCancelTitle,
+  "RequestActionButton.cancel": InvitationsRequestCancelButton,
+  "RequestStatus.layout.submitted": SubmitStatus,
+  "RequestStatus.layout.deleted": DeleteStatus,
+  "RequestStatus.layout.accepted": AcceptStatus,
+  "RequestStatus.layout.declined": DeclineStatus,
+  "RequestStatus.layout.cancelled": CancelStatus,
+  "RequestStatus.layout.expired": ExpireStatus,
 };
 
 const overriddenComponents = overrideStore.getAll();

--- a/invenio_communities/assets/semantic-ui/js/invenio_communities/members/member_requests/MemberRequestsResults.js
+++ b/invenio_communities/assets/semantic-ui/js/invenio_communities/members/member_requests/MemberRequestsResults.js
@@ -1,0 +1,55 @@
+/*
+ * This file is part of Invenio.
+ *
+ * Copyright (C) 2026 Northwestern University.
+ *
+ * Invenio is free software; you can redistribute it and/or modify it
+ * under the terms of the MIT License; see LICENSE file for more details.
+ */
+
+import React from "react";
+import { Grid } from "semantic-ui-react";
+import { i18next } from "@translations/invenio_communities/i18next";
+import { ResultsPerPage, Pagination, ResultsList } from "react-searchkit";
+import PropTypes from "prop-types";
+
+export const MemberRequestsResults = ({ paginationOptions, currentResultsState }) => {
+  const { total } = currentResultsState.data;
+  return (
+    total && (
+      <Grid>
+        <Grid.Row>
+          <Grid.Column width={16}>
+            <ResultsList />
+          </Grid.Column>
+        </Grid.Row>
+        <Grid.Row verticalAlign="middle">
+          <Grid.Column width={8} textAlign="right">
+            <Pagination
+              options={{
+                size: "mini",
+                showFirst: false,
+                showLast: false,
+              }}
+            />
+          </Grid.Column>
+          <Grid.Column textAlign="right" width={8}>
+            <ResultsPerPage
+              values={paginationOptions.resultsPerPage}
+              label={(cmp) => (
+                <>
+                  {cmp} {i18next.t("results per page")}
+                </>
+              )}
+            />
+          </Grid.Column>
+        </Grid.Row>
+      </Grid>
+    )
+  );
+};
+
+MemberRequestsResults.propTypes = {
+  paginationOptions: PropTypes.object.isRequired,
+  currentResultsState: PropTypes.object.isRequired,
+};

--- a/invenio_communities/assets/semantic-ui/js/invenio_communities/members/member_requests/MemberRequestsResults.js
+++ b/invenio_communities/assets/semantic-ui/js/invenio_communities/members/member_requests/MemberRequestsResults.js
@@ -33,7 +33,7 @@ export const MemberRequestsResults = ({ paginationOptions, currentResultsState }
               }}
             />
           </Grid.Column>
-          <Grid.Column textAlign="right" width={8}>
+          <Grid.Column width={8} textAlign="right">
             <ResultsPerPage
               values={paginationOptions.resultsPerPage}
               label={(cmp) => (

--- a/invenio_communities/assets/semantic-ui/js/invenio_communities/members/member_requests/MemberRequestsSearchBarElement.js
+++ b/invenio_communities/assets/semantic-ui/js/invenio_communities/members/member_requests/MemberRequestsSearchBarElement.js
@@ -1,26 +1,28 @@
 /*
  * This file is part of Invenio.
- * Copyright (C) 2022 CERN.
+ *
+ * Copyright (C) 2026 Northwestern University.
  *
  * Invenio is free software; you can redistribute it and/or modify it
  * under the terms of the MIT License; see LICENSE file for more details.
  */
-
 import React from "react";
 import { Input } from "semantic-ui-react";
 import { i18next } from "@translations/invenio_communities/i18next";
 import PropTypes from "prop-types";
 
-export const InvitationsSearchBarElement = ({
+export const MemberRequestsSearchBarElement = ({
   onBtnSearchClick,
   onInputChange,
   onKeyPress,
   queryString,
   uiProps,
+  className,
+  placeholder,
 }) => {
   return (
     <Input
-      className="invitation-searchbar"
+      className={className}
       action={{
         icon: "search",
         onClick: onBtnSearchClick,
@@ -28,7 +30,7 @@ export const InvitationsSearchBarElement = ({
         title: i18next.t("Search"),
       }}
       fluid
-      placeholder={i18next.t("Search in invitations...")}
+      placeholder={placeholder}
       onChange={(_, { value }) => {
         onInputChange(value);
       }}
@@ -39,14 +41,18 @@ export const InvitationsSearchBarElement = ({
   );
 };
 
-InvitationsSearchBarElement.propTypes = {
+MemberRequestsSearchBarElement.propTypes = {
   onBtnSearchClick: PropTypes.func.isRequired,
   onInputChange: PropTypes.func.isRequired,
   onKeyPress: PropTypes.func.isRequired,
   queryString: PropTypes.string.isRequired,
   uiProps: PropTypes.object,
+  className: PropTypes.string,
+  placeholder: PropTypes.string,
 };
 
-InvitationsSearchBarElement.defaultProps = {
+MemberRequestsSearchBarElement.defaultProps = {
   uiProps: null,
+  className: "",
+  placeholder: "",
 };

--- a/invenio_communities/assets/semantic-ui/js/invenio_communities/members/member_requests/MemberRequestsSearchBarElement.js
+++ b/invenio_communities/assets/semantic-ui/js/invenio_communities/members/member_requests/MemberRequestsSearchBarElement.js
@@ -1,11 +1,13 @@
 /*
  * This file is part of Invenio.
  *
+ * Copyright (C) 2022 CERN.
  * Copyright (C) 2026 Northwestern University.
  *
  * Invenio is free software; you can redistribute it and/or modify it
  * under the terms of the MIT License; see LICENSE file for more details.
  */
+
 import React from "react";
 import { Input } from "semantic-ui-react";
 import { i18next } from "@translations/invenio_communities/i18next";

--- a/invenio_communities/assets/semantic-ui/js/invenio_communities/members/membership_requests/MembershipRequestsEmptyResults.js
+++ b/invenio_communities/assets/semantic-ui/js/invenio_communities/members/membership_requests/MembershipRequestsEmptyResults.js
@@ -1,0 +1,47 @@
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import { Button, Header, Icon, Segment } from "semantic-ui-react";
+import { withState } from "react-searchkit";
+import { i18next } from "@translations/invenio_communities/i18next";
+
+class MembershipRequestsEmptyResultsCmp extends Component {
+  render() {
+    const { resetQuery, extraContent, queryString } = this.props;
+
+    return (
+      <Segment.Group>
+        <Segment placeholder textAlign="center">
+          <Header icon>
+            <Icon name="search" />
+            {i18next.t("No matching membership requests found.")}
+          </Header>
+          {queryString && (
+            <p>
+              <em>
+                {i18next.t("Current search")} "{queryString}"
+              </em>
+            </p>
+          )}
+          <Button primary onClick={() => resetQuery()}>
+            {i18next.t("Clear query")}
+          </Button>
+          {extraContent}
+        </Segment>
+      </Segment.Group>
+    );
+  }
+}
+
+MembershipRequestsEmptyResultsCmp.propTypes = {
+  resetQuery: PropTypes.func.isRequired,
+  queryString: PropTypes.string.isRequired,
+  extraContent: PropTypes.node,
+};
+
+MembershipRequestsEmptyResultsCmp.defaultProps = {
+  extraContent: null,
+};
+
+export const MembershipRequestsEmptyResults = withState(
+  MembershipRequestsEmptyResultsCmp
+);

--- a/invenio_communities/assets/semantic-ui/js/invenio_communities/members/membership_requests/MembershipRequestsEmptyResults.js
+++ b/invenio_communities/assets/semantic-ui/js/invenio_communities/members/membership_requests/MembershipRequestsEmptyResults.js
@@ -1,3 +1,12 @@
+/*
+ * This file is part of Invenio.
+ *
+ * Copyright (C) 2026 Northwestern University.
+ *
+ * Invenio is free software; you can redistribute it and/or modify it
+ * under the terms of the MIT License; see LICENSE file for more details.
+ */
+
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { Button, Header, Icon, Segment } from "semantic-ui-react";

--- a/invenio_communities/assets/semantic-ui/js/invenio_communities/members/membership_requests/MembershipRequestsResultItem.js
+++ b/invenio_communities/assets/semantic-ui/js/invenio_communities/members/membership_requests/MembershipRequestsResultItem.js
@@ -1,0 +1,115 @@
+/*
+ * This file is part of Invenio.
+ *
+ * Copyright (C) 2026 Northwestern University.
+ *
+ * Invenio is free software; you can redistribute it and/or modify it
+ * under the terms of the MIT License; see LICENSE file for more details.
+ */
+
+import { RequestActionController } from "@js/invenio_requests/request/actions/RequestActionController";
+import RequestStatus from "@js/invenio_requests/request/RequestStatus";
+import { i18next } from "@translations/invenio_communities/i18next";
+import PropTypes from "prop-types";
+import React, { Component } from "react";
+import { Image } from "react-invenio-forms";
+import { Grid, Item, Table } from "semantic-ui-react";
+
+import { MembershipRequestsContext } from "../../api/membershipRequests/MembershipRequestsContextProvider";
+import { RoleDropdown } from "../components/dropdowns";
+import { buildRequestFromMember, formattedTime } from "../utils";
+
+export class MembershipRequestsResultItem extends Component {
+  constructor(props) {
+    super(props);
+    const { result } = this.props;
+    this.state = { membershipRequest: result };
+  }
+
+  static contextType = MembershipRequestsContext;
+
+  update = (data, value) => {
+    const { membershipRequest } = this.state;
+    this.setState({ membershipRequest: { ...membershipRequest, ...{ role: value } } });
+  };
+
+  actionSuccessCallback = () => undefined;
+
+  render() {
+    const {
+      config: { rolesCanAssign },
+      community,
+    } = this.props;
+
+    const {
+      membershipRequest: { member },
+      membershipRequest,
+    } = this.state;
+
+    const request = buildRequestFromMember(membershipRequest, ["accept", "decline"]);
+    const { api: membershipRequestsApi } = this.context;
+    const roles = rolesCanAssign[member.type];
+    const expiration = formattedTime(request.expires_at);
+    const linkToRequest = membershipRequest.links.self_html;
+
+    return (
+      <Table.Row className="community-member-item">
+        <Table.Cell>
+          <Grid textAlign="left" verticalAlign="middle">
+            <Grid.Column>
+              <Item className="flex align-items-center" key={membershipRequest.id}>
+                <Image src={member.avatar} avatar circular className="mr-10" />
+                <Item.Content>
+                  <Item.Header size="small" as="b">
+                    <a href={linkToRequest}>{member.name}</a>
+                  </Item.Header>
+                  {member.description && (
+                    <Item.Meta>
+                      <div className="truncate-lines-1">{member.description}</div>
+                    </Item.Meta>
+                  )}
+                </Item.Content>
+              </Item>
+            </Grid.Column>
+          </Grid>
+        </Table.Cell>
+        <Table.Cell data-label={i18next.t("Status")}>
+          <RequestStatus status={request.status} />
+        </Table.Cell>
+        <Table.Cell
+          aria-label={i18next.t("Expires") + " " + expiration}
+          data-label={i18next.t("Expires")}
+        >
+          {expiration}
+        </Table.Cell>
+        <Table.Cell data-label={i18next.t("Role")}>
+          <RoleDropdown
+            roles={roles}
+            action={membershipRequestsApi.updateRole}
+            successCallback={this.update}
+            disabled={!membershipRequest.permissions.can_update_role}
+            currentValue={membershipRequest.role}
+            resource={membershipRequest}
+            label={i18next.t("Role") + " " + membershipRequest.role}
+          />
+        </Table.Cell>
+        <Table.Cell data-label={i18next.t("Actions")}>
+          <RequestActionController
+            request={request}
+            actionSuccessCallback={() => {
+              window.location.reload();
+            }}
+          />
+        </Table.Cell>
+      </Table.Row>
+    );
+  }
+}
+
+MembershipRequestsResultItem.propTypes = {
+  result: PropTypes.object.isRequired,
+  config: PropTypes.object.isRequired,
+  community: PropTypes.object.isRequired,
+};
+
+MembershipRequestsResultItem.defaultProps = {};

--- a/invenio_communities/assets/semantic-ui/js/invenio_communities/members/membership_requests/MembershipRequestsResultsContainer.js
+++ b/invenio_communities/assets/semantic-ui/js/invenio_communities/members/membership_requests/MembershipRequestsResultsContainer.js
@@ -1,0 +1,36 @@
+/*
+ * This file is part of Invenio.
+ *
+ * Copyright (C) 2026 Northwestern University.
+ *
+ * Invenio is free software; you can redistribute it and/or modify it
+ * under the terms of the MIT License; see LICENSE file for more details.
+ */
+
+import { i18next } from "@translations/invenio_communities/i18next";
+import PropTypes from "prop-types";
+import React from "react";
+import { Table } from "semantic-ui-react";
+
+export const MembershipRequestsResultsContainer = ({ results }) => {
+  return (
+    <Table>
+      <Table.Header>
+        <Table.Row>
+          <Table.HeaderCell width={4}>{i18next.t("Name")}</Table.HeaderCell>
+          <Table.HeaderCell width={2}>{i18next.t("Status")}</Table.HeaderCell>
+          <Table.HeaderCell width={3}>{i18next.t("Expires")}</Table.HeaderCell>
+          <Table.HeaderCell width={3}>{i18next.t("Role")}</Table.HeaderCell>
+          <Table.HeaderCell width={4}>{i18next.t("Actions")}</Table.HeaderCell>
+        </Table.Row>
+      </Table.Header>
+      <Table.Body>{results}</Table.Body>
+    </Table>
+  );
+};
+
+MembershipRequestsResultsContainer.propTypes = {
+  results: PropTypes.array.isRequired,
+};
+
+MembershipRequestsResultsContainer.defaultProps = {};

--- a/invenio_communities/assets/semantic-ui/js/invenio_communities/members/membership_requests/MembershipRequestsSearchLayout.js
+++ b/invenio_communities/assets/semantic-ui/js/invenio_communities/members/membership_requests/MembershipRequestsSearchLayout.js
@@ -1,0 +1,65 @@
+/*
+ * This file is part of Invenio.
+ *
+ * Copyright (C) 2026 Northwestern University.
+ *
+ * Invenio is free software; you can redistribute it and/or modify it
+ * under the terms of the MIT License; see LICENSE file for more details.
+ */
+
+import { RequestStatusFilter } from "@js/invenio_requests/search";
+import { SearchAppResultsPane } from "@js/invenio_search_ui/components";
+import { SearchFilters } from "@js/invenio_search_ui/components/SearchFilters";
+import PropTypes from "prop-types";
+import React, { Component } from "react";
+import { SearchBar, Sort } from "react-searchkit";
+
+import { Filters } from "../Filters";
+import { FilterLabels } from "../components/FilterLabels";
+
+export class MembershipRequestsSearchLayout extends Component {
+  render() {
+    const { config, roles, appName } = this.props;
+
+    const filtersClass = new Filters(roles);
+    const customFilters = filtersClass.getMembershipRequestsFilters();
+
+    return (
+      <>
+        {/* auto column grid used instead of SUI grid for better searchbar width adjustment */}
+        <div className="auto-column-grid">
+          <div className="flex column-mobile">
+            <div className="mobile only rel-mb-1 flex align-items-center justify-space-between">
+              <RequestStatusFilter keepFiltersOnUpdate />
+            </div>
+            <div className="tablet computer only only rel-mr-2">
+              <RequestStatusFilter keepFiltersOnUpdate />
+            </div>
+            <SearchBar fluid />
+          </div>
+          <div className="flex align-items-center column-mobile">
+            <div className="tablet only mr-5" />
+            <div className="full-width flex align-items-center justify-end column-mobile">
+              <SearchFilters customFilters={customFilters} />
+              <Sort values={config.sortOptions} />
+            </div>
+          </div>
+        </div>
+        <div className="rel-mb-1">
+          <FilterLabels ignoreFilters={["is_open"]} />
+        </div>
+        <SearchAppResultsPane layoutOptions={config.layoutOptions} appName={appName} />
+      </>
+    );
+  }
+}
+
+MembershipRequestsSearchLayout.propTypes = {
+  config: PropTypes.object.isRequired,
+  roles: PropTypes.array.isRequired,
+  appName: PropTypes.string,
+};
+
+MembershipRequestsSearchLayout.defaultProps = {
+  appName: "",
+};

--- a/invenio_communities/assets/semantic-ui/js/invenio_communities/members/membership_requests/MembershipRequestsSearchLayout.js
+++ b/invenio_communities/assets/semantic-ui/js/invenio_communities/members/membership_requests/MembershipRequestsSearchLayout.js
@@ -46,7 +46,7 @@ export class MembershipRequestsSearchLayout extends Component {
           </div>
         </div>
         <div className="rel-mb-1">
-          <FilterLabels ignoreFilters={["is_open"]} />
+          <FilterLabels ignoreFilters={["is_open"]} roles={roles} />
         </div>
         <SearchAppResultsPane layoutOptions={config.layoutOptions} appName={appName} />
       </>

--- a/invenio_communities/assets/semantic-ui/js/invenio_communities/members/membership_requests/index.js
+++ b/invenio_communities/assets/semantic-ui/js/invenio_communities/members/membership_requests/index.js
@@ -1,0 +1,97 @@
+/*
+ * This file is part of Invenio.
+ *
+ * Copyright (C) 2026 Northwestern University.
+ *
+ * Invenio is free software; you can redistribute it and/or modify it
+ * under the terms of the MIT License; see LICENSE file for more details.
+ */
+
+import { parametrize, overrideStore } from "react-overridable";
+import { createSearchAppInit } from "@js/invenio_search_ui";
+import { DropdownSort } from "@js/invenio_search_ui/components";
+import { i18next } from "@translations/invenio_communities/i18next";
+import {
+  RequestAcceptButton,
+  RequestDeclineButton,
+} from "@js/invenio_requests/components/Buttons";
+import {
+  RequestAcceptModalTrigger,
+  RequestDeclineModalTrigger,
+} from "@js/invenio_requests/components/ModalTriggers";
+import {
+  SubmitStatus,
+  DeleteStatus,
+  AcceptStatus,
+  DeclineStatus,
+  CancelStatus,
+  ExpireStatus,
+} from "@js/invenio_requests/request";
+
+import { MembershipRequestsContextProvider as ContextProvider } from "../../api/membershipRequests/MembershipRequestsContextProvider";
+import { MemberRequestsResults } from "../member_requests/MemberRequestsResults";
+import { MemberRequestsSearchBarElement } from "../member_requests/MemberRequestsSearchBarElement";
+import { MembershipRequestsEmptyResults } from "./MembershipRequestsEmptyResults";
+import { MembershipRequestsResultsContainer } from "./MembershipRequestsResultsContainer";
+import { MembershipRequestsResultItem as ResultItem } from "./MembershipRequestsResultItem";
+import { MembershipRequestsSearchLayout as SearchLayout } from "./MembershipRequestsSearchLayout";
+
+const dataAttr = document.getElementById(
+  "community-membership-requests-search-root"
+).dataset;
+const community = JSON.parse(dataAttr.community);
+const communitiesAllRoles = JSON.parse(dataAttr.communitiesAllRoles);
+const communitiesRolesCanAssign = JSON.parse(dataAttr.communitiesRolesCanAssign);
+
+const appName = "InvenioCommunities.MembershipRequestsSearch";
+
+const MembershipRequestsContextProvider = parametrize(ContextProvider, {
+  community: community,
+});
+
+const MembershipRequestsSearchLayout = parametrize(SearchLayout, {
+  roles: communitiesAllRoles,
+  appName: appName,
+});
+
+const MembershipRequestsSearchBarElement = parametrize(MemberRequestsSearchBarElement, {
+  className: "membership-requests-searchbar",
+  placeholder: i18next.t("Search in membership requests..."),
+});
+
+const MembershipRequestsResultItem = parametrize(ResultItem, {
+  config: { rolesCanAssign: communitiesRolesCanAssign },
+  community: community,
+});
+
+const defaultComponents = {
+  [`${appName}.SearchApp.layout`]: MembershipRequestsSearchLayout,
+  [`${appName}.SearchBar.element`]: MembershipRequestsSearchBarElement,
+  [`${appName}.Sort.element`]: DropdownSort,
+  [`${appName}.ResultsList.container`]: MembershipRequestsResultsContainer,
+  [`${appName}.SearchApp.results`]: MemberRequestsResults,
+  [`${appName}.ResultsList.item`]: MembershipRequestsResultItem,
+  [`${appName}.EmptyResults.element`]: MembershipRequestsEmptyResults,
+  // The RequestModalTriggers are generic enough to be reused here
+  "RequestActionModalTrigger.accept": RequestAcceptModalTrigger,
+  "RequestActionModalTrigger.decline": RequestDeclineModalTrigger,
+  "RequestActionButton.accept": RequestAcceptButton,
+  "RequestActionButton.decline": RequestDeclineButton,
+  "RequestStatus.layout.submitted": SubmitStatus,
+  "RequestStatus.layout.deleted": DeleteStatus,
+  "RequestStatus.layout.accepted": AcceptStatus,
+  "RequestStatus.layout.declined": DeclineStatus,
+  "RequestStatus.layout.cancelled": CancelStatus,
+  "RequestStatus.layout.expired": ExpireStatus,
+};
+
+const overriddenComponents = overrideStore.getAll();
+
+// Auto-initialize search app
+createSearchAppInit(
+  { ...defaultComponents, ...overriddenComponents }, // defaultcomponents =
+  true, // autoInit =
+  "invenio-search-config", // autoInitDataAttr =
+  true, // multi =
+  MembershipRequestsContextProvider // ContainerComponent =
+);

--- a/invenio_communities/assets/semantic-ui/js/invenio_communities/members/utils.js
+++ b/invenio_communities/assets/semantic-ui/js/invenio_communities/members/utils.js
@@ -1,0 +1,43 @@
+/*
+ * This file is part of Invenio.
+ * Copyright (C) 2024 Northwestern University.
+ *
+ * Invenio is free software; you can redistribute it and/or modify it
+ * under the terms of the MIT License; see LICENSE file for more details.
+ */
+
+import { i18next } from "@translations/invenio_communities/i18next";
+import { DateTime } from "luxon";
+import _cloneDeep from "lodash/cloneDeep";
+import _pick from "lodash/pick";
+
+/**
+ * Format given `at` time relative to current time.
+ *
+ * @export
+ * @param {string} at
+ * @return {string}
+ */
+export function formattedTime(at) {
+  return DateTime.fromISO(at).setLocale(i18next.language).toRelative();
+}
+
+/**
+ * Build a "Request" object for the purposes of a controller and own sanity.
+ *
+ * This means extracting the request-related data from the Member object
+ * and repackaging them like a Request object expected by Request components.
+ * Member objects are members, invitations and membership requests.
+ *
+ * @export
+ * @param {Object} member - search result on Members JSON API
+ * @param {Array<string>} keysOfActionsLinks
+ * @return {Object}
+ */
+export function buildRequestFromMember(member, keysOfActionsLinks) {
+  let request = _cloneDeep(member.request);
+  request.links = {
+    actions: _pick(member.links.actions, keysOfActionsLinks),
+  };
+  return request;
+}

--- a/invenio_communities/assets/semantic-ui/js/invenio_communities/members/utils.js
+++ b/invenio_communities/assets/semantic-ui/js/invenio_communities/members/utils.js
@@ -1,6 +1,6 @@
 /*
  * This file is part of Invenio.
- * Copyright (C) 2024 Northwestern University.
+ * Copyright (C) 2024-2026 Northwestern University.
  *
  * Invenio is free software; you can redistribute it and/or modify it
  * under the terms of the MIT License; see LICENSE file for more details.

--- a/invenio_communities/config.py
+++ b/invenio_communities/config.py
@@ -4,6 +4,7 @@
 # Copyright (C) 2016-2025 CERN.
 # Copyright (C) 2023 Graz University of Technology.
 # Copyright (C) 2023 KTH Royal Institute of Technology.
+# Copyright (C) 2026 Northwestern University.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -13,6 +14,7 @@
 from datetime import timedelta
 
 from invenio_i18n import lazy_gettext as _
+from invenio_requests.services.requests import facets as facets_for_requests
 
 from invenio_communities.communities.records.systemfields.access import (
     RecordSubmissionPolicyEnum,
@@ -30,16 +32,17 @@ COMMUNITIES_ROUTES = {
     "new": "/communities-new",
     "deprecated_new": "/communities/new",
     "upload": "/communities/<pid_value>/upload",
-    "settings": "/communities/<pid_value>/settings",
     "requests": "/communities/<pid_value>/requests",
     "subcommunities": "/communities/<pid_value>/browse/subcommunities",
     "new_subcommunity": "/communities/<pid_value>/subcommunities/new",
+    "settings": "/communities/<pid_value>/settings",
     "settings_privileges": "/communities/<pid_value>/settings/privileges",
     "settings_submission_policy": "/communities/<pid_value>/settings/submission-policy",
     "settings_pages": "/communities/<pid_value>/settings/pages",
     "settings_collections": "/communities/<pid_value>/settings/collections",
     "members": "/communities/<pid_value>/members",
     "invitations": "/communities/<pid_value>/invitations",
+    "membership_requests": "/communities/<pid_value>/membership-requests",
     "about": "/communities/<pid_value>/about",
     "curation_policy": "/communities/<pid_value>/curation-policy",
 }
@@ -166,7 +169,7 @@ COMMUNITIES_MEMBERS_SEARCH = {
     "facets": ["role", "visibility"],
     "sort": ["bestmatch", "name", "newest", "oldest"],
 }
-"""Community requests search configuration (i.e list of community requests)"""
+"""Community members search configuration (i.e list of community members)"""
 
 COMMUNITIES_MEMBERS_SORT_OPTIONS = {
     "bestmatch": dict(
@@ -205,7 +208,7 @@ COMMUNITIES_MEMBERS_FACETS = {
 """Available facets defined for this module."""
 
 COMMUNITIES_INVITATIONS_SEARCH = {
-    "facets": ["type", "status"],
+    "facets": ["type", "status"],  # what is type?
     "sort": ["bestmatch", "name", "newest", "oldest"],
 }
 """Community invitations search configuration (i.e list of community invitations)"""
@@ -230,13 +233,33 @@ COMMUNITIES_INVITATIONS_SORT_OPTIONS = {
 }
 """Definitions of available record sort options."""
 
-
 COMMUNITIES_INVITATIONS_EXPIRES_IN = timedelta(days=30)
 """"Default amount of time before an invitation expires."""
 
+COMMUNITIES_MEMBERSHIP_REQUESTS_SEARCH = {
+    "facets": ["role", "status"],
+    "sort": ["bestmatch", "name", "newest", "oldest"],
+}
+""""Community membership requests search configuration."""
+
+COMMUNITIES_MEMBERSHIP_REQUESTS_FACETS = {
+    "role": {
+        "facet": facets.role,
+        "ui": {
+            "field": "role",
+        },
+    },
+    "status": {
+        "facet": facets_for_requests.status,
+        "ui": {
+            "field": "role",
+        },
+    },
+}
+"""Available facets for membership requests."""
+
 COMMUNITIES_LOGO_MAX_FILE_SIZE = 10**6
 """Community logo size quota, in bytes."""
-
 
 COMMUNITIES_NAMESPACES = {}
 """Custom fields namespaces.

--- a/invenio_communities/config.py
+++ b/invenio_communities/config.py
@@ -208,7 +208,7 @@ COMMUNITIES_MEMBERS_FACETS = {
 """Available facets defined for this module."""
 
 COMMUNITIES_INVITATIONS_SEARCH = {
-    "facets": ["type", "status"],  # what is type?
+    "facets": ["type", "status"],
     "sort": ["bestmatch", "name", "newest", "oldest"],
 }
 """Community invitations search configuration (i.e list of community invitations)"""

--- a/invenio_communities/members/resources/config.py
+++ b/invenio_communities/members/resources/config.py
@@ -47,7 +47,9 @@ class MemberResourceConfig(RecordResourceConfig):
         AlreadyMemberError: create_error_handler(
             HTTPJSONException(
                 code=400,
-                description=_("A member was already added or invited."),
+                description=_(
+                    "One of the submitted entity is already part of the community or is already being assessed. The entire action was cancelled."  # noqa
+                ),
             )
         ),
         CommunityDeletedError: create_error_handler(

--- a/invenio_communities/members/resources/config.py
+++ b/invenio_communities/members/resources/config.py
@@ -48,7 +48,7 @@ class MemberResourceConfig(RecordResourceConfig):
             HTTPJSONException(
                 code=400,
                 description=_(
-                    "One of the submitted entity is already part of the community or is already being assessed. The entire action was cancelled."  # noqa
+                    "One of the submitted entity is already a member or pending a decision. The entire action was cancelled."  # noqa
                 ),
             )
         ),

--- a/invenio_communities/members/services/config.py
+++ b/invenio_communities/members/services/config.py
@@ -25,7 +25,10 @@ from ..records import Member
 from ..records.api import ArchivedMemberRequest
 from . import facets
 from .components import CommunityMemberCachingComponent
-from .links import MemberRequestActionsEndpointLinks
+from .links import (
+    MemberRequestActionsEndpointLinks,
+    MemberRequestCommunityDashboardEndpointLink,
+)
 from .schemas import MemberEntitySchema
 
 
@@ -182,6 +185,10 @@ class MemberServiceConfig(RecordServiceConfig, ConfiguratorMixin):
 
     links_item = {
         "actions": MemberRequestActionsEndpointLinks(),
+        # We define the self_html of a Member to be the community dashboard one of its
+        # assocaated Request (in this context, the user dashboard endpoint is never
+        # appropriate)
+        "self_html": MemberRequestCommunityDashboardEndpointLink(),
     }
     # ResultList configurations
     links_search = pagination_endpoint_links(

--- a/invenio_communities/members/services/config.py
+++ b/invenio_communities/members/services/config.py
@@ -185,8 +185,8 @@ class MemberServiceConfig(RecordServiceConfig, ConfiguratorMixin):
 
     links_item = {
         "actions": MemberRequestActionsEndpointLinks(),
-        # We define the self_html of a Member to be the community dashboard one of its
-        # assocaated Request (in this context, the user dashboard endpoint is never
+        # We define the self_html of a Member to be the community dashboard link of its
+        # associated Request (in this context, the user dashboard endpoint is never
         # appropriate)
         "self_html": MemberRequestCommunityDashboardEndpointLink(),
     }

--- a/invenio_communities/members/services/links.py
+++ b/invenio_communities/members/services/links.py
@@ -7,10 +7,13 @@
 
 """Members Service links."""
 
+from collections import namedtuple
+
 from invenio_records_resources.services.base.links import (
     EndpointLink,
 )
 from invenio_requests.proxies import current_request_type_registry
+from invenio_requests.services.links import RequestTypeDependentEndpointLink
 
 from .request import CommunityInvitation, MembershipRequestRequestType
 
@@ -151,3 +154,74 @@ class MemberRequestActionsEndpointLinks:
                 links[action] = self._endpoint_link.expand(obj, ctx)
 
         return links
+
+
+class MemberRequestCommunityDashboardEndpointLink:
+    """EndpointLink for community dashboard endpoint of request of member.
+
+    WHY: A Member doesn't doesn't store its associated request in its entirety in same
+         db/index entry (naturally). So the blunt approach of reusing Request dependent
+         functionality is not possible without a high performance cost (to retrieve each
+         full request) or an incomplete and error-prone faked interface.
+
+         So we use a different approach instead. At the cost of not reusing the
+         self_html link defined in the MemberRequest, we define the self_html links here
+         in the context of a Member service call (Member JSON API). Contextual knowledge
+         is leveraged to cut to the chase.
+    """
+
+    def __init__(self):
+        """docstring."""
+
+    def _select_link(self, obj, context):
+        """Select EndpointLink corresponding to type of request of Member.
+
+        :param obj: api.Member
+        :param context: dict of context variables
+        return EndpointLink
+        """
+        member = obj
+
+        link_no_op = EndpointLink("", when=lambda obj, vars: False)
+
+        # No member request link for active member or member without request
+        # (added directly)
+        if member.active or not member.get("request"):
+            return link_no_op
+
+        # Not all members may have a request with a type stored since the request type
+        # was not stored originally. But in that case, because at this point we know the
+        # Member is inactive and has a request without stored type, the request must be
+        # an invitation (it's a legacy invitation).
+        request_type_id = member["request"].get("type") or "community-invitation"
+
+        if request_type_id == CommunityInvitation.type_id:
+            endpoint = "invenio_app_rdm_requests.community_dashboard_request_view"
+        elif request_type_id == MembershipRequestRequestType.type_id:
+            endpoint = "invenio_app_rdm_requests.community_dashboard_membership_request_view"  # noqa
+        else:
+            # In case something strange / future-proofing
+            return link_no_op
+
+        return EndpointLink(
+            endpoint,
+            params=["pid_value", "request_pid_value"],
+            vars=lambda obj, vars: (
+                vars.update(
+                    # override the pid_value to use the community slug since this
+                    # is a UI URL
+                    pid_value=vars["community_slug"],
+                    request_pid_value=str(member.request_id),
+                ),
+            ),
+        )
+
+    def should_render(self, obj, context):
+        """Should render."""
+        link = self._select_link(obj, context)
+        return link.should_render(obj, context)
+
+    def expand(self, obj, context):
+        """Expand the link with obj and context."""
+        link = self._select_link(obj, context)
+        return link.expand(obj, context)

--- a/invenio_communities/members/services/links.py
+++ b/invenio_communities/members/services/links.py
@@ -7,13 +7,10 @@
 
 """Members Service links."""
 
-from collections import namedtuple
-
 from invenio_records_resources.services.base.links import (
     EndpointLink,
 )
 from invenio_requests.proxies import current_request_type_registry
-from invenio_requests.services.links import RequestTypeDependentEndpointLink
 
 from .request import CommunityInvitation, MembershipRequestRequestType
 
@@ -196,6 +193,9 @@ class MemberRequestCommunityDashboardEndpointLink:
         request_type_id = member["request"].get("type") or "community-invitation"
 
         if request_type_id == CommunityInvitation.type_id:
+            # TODO: replace by
+            #   invenio_app_rdm_requests.community_dashboard_invitation_view
+            # when view implemented in invenio-app-rdm
             endpoint = "invenio_app_rdm_requests.community_dashboard_request_view"
         elif request_type_id == MembershipRequestRequestType.type_id:
             endpoint = "invenio_app_rdm_requests.community_dashboard_membership_request_view"  # noqa

--- a/invenio_communities/members/services/request.py
+++ b/invenio_communities/members/services/request.py
@@ -198,7 +198,9 @@ class CommunityInvitation(RequestType):
                 vars=update_vars_for_user_dashboard_request_view,
             ),
             else_=EndpointLink(
-                # Ideally have a _WithFallbackEndpointLink()
+                # TODO: Change to
+                # invenio_app_rdm_requests.community_dashboard_invitation_view
+                # when defined in invenio-app-rdm
                 "invenio_app_rdm_requests.community_dashboard_request_view",
                 params=["pid_value", "request_pid_value"],
                 vars=update_vars_for_community_dashboard_request_view,

--- a/invenio_communities/searchapp.py
+++ b/invenio_communities/searchapp.py
@@ -59,6 +59,16 @@ def search_app_context():
             sort_options=current_app.config["COMMUNITIES_INVITATIONS_SORT_OPTIONS"],
             headers={"Accept": "application/json"},
             initial_filters=[["is_open", "true"]],
-            endpoint="/api/requests",
+            endpoint="/api/requests",  # remove
+        ),
+        "search_app_communities_membership_requests_config": partial(
+            search_app_config,
+            config_name="COMMUNITIES_MEMBERSHIP_REQUESTS_SEARCH",
+            available_facets=current_app.config[
+                "COMMUNITIES_MEMBERSHIP_REQUESTS_FACETS"
+            ],
+            sort_options=current_app.config["COMMUNITIES_MEMBERS_SORT_OPTIONS"],
+            headers={"Accept": "application/json"},
+            initial_filters=[["is_open", "true"]],
         ),
     }

--- a/invenio_communities/searchapp.py
+++ b/invenio_communities/searchapp.py
@@ -59,7 +59,6 @@ def search_app_context():
             sort_options=current_app.config["COMMUNITIES_INVITATIONS_SORT_OPTIONS"],
             headers={"Accept": "application/json"},
             initial_filters=[["is_open", "true"]],
-            endpoint="/api/requests",  # remove
         ),
         "search_app_communities_membership_requests_config": partial(
             search_app_config,

--- a/invenio_communities/templates/semantic-ui/invenio_communities/details/members/base.html
+++ b/invenio_communities/templates/semantic-ui/invenio_communities/details/members/base.html
@@ -19,6 +19,7 @@
     {%- set menu_items = {
       'members': (_('Members'), url_for('invenio_communities.members', pid_value=community_ui['slug']), permissions.can_read),
       'invitations': (_('Invitations'), url_for('invenio_communities.invitations', pid_value=community_ui['slug']), permissions.can_search_invites),
+      'membership_requests': (_('Membership Requests'), url_for('invenio_communities.membership_requests', pid_value=community_ui['slug']), permissions.can_search_membership_requests),
     } %}
     <div class="three wide computer sixteen wide tablet sixteen wide mobile column">
       <div class="ui vertical computer horizontal tablet horizontal mobile menu theme-primary-menu">

--- a/invenio_communities/templates/semantic-ui/invenio_communities/details/members/membership_requests.html
+++ b/invenio_communities/templates/semantic-ui/invenio_communities/details/members/membership_requests.html
@@ -1,0 +1,39 @@
+{# -*- coding: utf-8 -*-
+
+  This file is part of Invenio.
+  Copyright (C) 2026 Northwestern University.
+
+  Invenio is free software; you can redistribute it and/or modify it
+  under the terms of the MIT License; see LICENSE file for more details.
+#}
+
+{% extends "invenio_communities/details/members/base.html" %}
+
+{%- block javascript %}
+  {{ super() }}
+  {{ webpack['invenio-communities-membership-requests.js'] }}
+{%- endblock javascript %}
+
+{% set active_members_menu_item = 'membership_requests' %}
+{% set active_community_header_menu_item= 'members' %}
+
+{%- block settings_body %}
+
+  {# data-groups-enabled='{{ config.USERS_RESOURCES_GROUPS_ENABLED | tojson }}' #}
+  <div class="thirteen wide computer sixteen wide tablet sixteen wide mobile column">
+    <div
+      id="community-membership-requests-search-root"
+      data-community='{{ community_ui | tojson }}'
+      data-communities-all-roles='{{ config.COMMUNITIES_ROLES | tojson }}'
+      data-communities-roles-can-assign='{{ roles_can_assign | tojson }}'
+      data-permissions='{{ permissions | tojson }}'
+      data-invenio-search-config='{{
+        search_app_communities_membership_requests_config(
+          app_id="InvenioCommunities.MembershipRequestsSearch",
+          endpoint=community_ui["links"]["membership_requests"]
+        ) | tojson }}'>
+    </div>
+  </div>
+
+
+{%- endblock settings_body %}

--- a/invenio_communities/templates/semantic-ui/invenio_communities/details/members/membership_requests.html
+++ b/invenio_communities/templates/semantic-ui/invenio_communities/details/members/membership_requests.html
@@ -1,10 +1,10 @@
 {# -*- coding: utf-8 -*-
 
-  This file is part of Invenio.
   Copyright (C) 2026 Northwestern University.
 
-  Invenio is free software; you can redistribute it and/or modify it
-  under the terms of the MIT License; see LICENSE file for more details.
+  Invenio-Communities is free software; you can redistribute it and/or modify
+  it under the terms of the MIT License; see LICENSE file for more details.
+
 #}
 
 {% extends "invenio_communities/details/members/base.html" %}
@@ -19,7 +19,6 @@
 
 {%- block settings_body %}
 
-  {# data-groups-enabled='{{ config.USERS_RESOURCES_GROUPS_ENABLED | tojson }}' #}
   <div class="thirteen wide computer sixteen wide tablet sixteen wide mobile column">
     <div
       id="community-membership-requests-search-root"

--- a/invenio_communities/views/communities.py
+++ b/invenio_communities/views/communities.py
@@ -126,6 +126,9 @@ MEMBER_POLICY_FIELDS = [
 ]
 
 
+# Permissions to determine relevant to community pages
+
+
 HEADER_PERMISSIONS = {
     "read",
     "update",
@@ -514,6 +517,22 @@ def invitations(pid_value, community, community_ui):
         community_ui=community_ui,
         community=community,
         roles_can_invite=_get_roles_can_invite(community.id),
+        permissions=permissions,
+    )
+
+
+@pass_community(serialize=True)
+def membership_requests(pid_value, community, community_ui):
+    """Community membership requests page."""
+    permissions = community.has_permissions_to(MEMBERS_PERMISSIONS)
+    if not permissions["can_search_membership_requests"]:
+        raise PermissionDeniedError()
+    return render_community_theme_template(
+        "invenio_communities/details/members/membership_requests.html",
+        theme=community_ui.get("theme", {}),
+        community_ui=community_ui,
+        community=community,
+        roles_can_assign=_get_roles_can_invite(community.id),  # to change?
         permissions=permissions,
     )
 

--- a/invenio_communities/views/communities.py
+++ b/invenio_communities/views/communities.py
@@ -126,7 +126,7 @@ MEMBER_POLICY_FIELDS = [
 ]
 
 
-# Permissions to determine relevant to community pages
+# Permissions relevant to community actions
 
 
 HEADER_PERMISSIONS = {
@@ -532,7 +532,8 @@ def membership_requests(pid_value, community, community_ui):
         theme=community_ui.get("theme", {}),
         community_ui=community_ui,
         community=community,
-        roles_can_assign=_get_roles_can_invite(community.id),  # to change?
+        # Same as invite ones so just reuse
+        roles_can_assign=_get_roles_can_invite(community.id),
         permissions=permissions,
     )
 

--- a/invenio_communities/views/ui.py
+++ b/invenio_communities/views/ui.py
@@ -43,6 +43,7 @@ from .communities import (
     community_theme_css_config,
     invitations,
     members,
+    membership_requests,
 )
 from .decorators import warn_deprecation
 
@@ -198,35 +199,33 @@ def create_ui_blueprint(app):
         routes["settings"],
         view_func=communities_settings,
     )
-
-    blueprint.add_url_rule(
-        routes["requests"],
-        view_func=communities_requests,
-    )
-
     blueprint.add_url_rule(
         routes["settings_privileges"],
         view_func=communities_settings_privileges,
     )
-
     blueprint.add_url_rule(
         routes["settings_submission_policy"],
         view_func=communities_settings_submission_policy,
     )
-
     blueprint.add_url_rule(
         routes["settings_pages"],
         view_func=communities_settings_pages,
     )
-
     blueprint.add_url_rule(
         routes["settings_collections"],
         view_func=communities_settings_collections,
     )
 
-    blueprint.add_url_rule(routes["members"], view_func=members)
+    # Requests tab routes
+    blueprint.add_url_rule(
+        routes["requests"],
+        view_func=communities_requests,
+    )
 
+    # Members tab routes
+    blueprint.add_url_rule(routes["members"], view_func=members)
     blueprint.add_url_rule(routes["invitations"], view_func=invitations)
+    blueprint.add_url_rule(routes["membership_requests"], view_func=membership_requests)
 
     # theme injection view
     blueprint.add_url_rule(

--- a/invenio_communities/webpack.py
+++ b/invenio_communities/webpack.py
@@ -39,6 +39,7 @@ communities = WebpackThemeBundle(
                 "invenio-communities-members-manager": "./js/invenio_communities/members/members/manager_view/index.js",
                 "invenio-communities-members-public": "./js/invenio_communities/members/members/public_view/index.js",
                 "invenio-communities-invitations": "./js/invenio_communities/members/invitations/index.js",
+                "invenio-communities-membership-requests": "./js/invenio_communities/members/membership_requests/index.js",
                 "invenio-communities-carousel": "./js/invenio_communities/community/communitiesCarousel/index.js",
                 "invenio-communities-admin-search": "./js/invenio_communities/administration/search.js",
                 "invenio-communities-featured": "./js/invenio_communities/community/featuredCommunities/index.js",

--- a/tests/members/test_members_resource.py
+++ b/tests/members/test_members_resource.py
@@ -385,6 +385,7 @@ def test_search_invitations(
         "actions": {
             "cancel": f"https://127.0.0.1:5000/api/requests/{request_id}/actions/cancel",  # noqa
         },
+        "self_html": f"https://127.0.0.1:5000/communities/{community_slug}/invitations/{request_id}",  # noqa
     }
     assert expected_links == hit["links"]
 
@@ -492,6 +493,7 @@ def test_get_search_membership_requests(
             "accept": f"https://127.0.0.1:5000/api/requests/{request_id}/actions/accept",  # noqa
             "decline": f"https://127.0.0.1:5000/api/requests/{request_id}/actions/decline",  # noqa
         },
+        "self_html": f"https://127.0.0.1:5000/communities/{community_slug}/membership-requests/{request_id}",  # noqa
     }
     assert expected_links == hit["links"]
 

--- a/tests/members/test_members_resource.py
+++ b/tests/members/test_members_resource.py
@@ -406,7 +406,7 @@ def test_search_invitations(
         "actions": {
             "cancel": f"https://127.0.0.1:5000/api/requests/{request_id}/actions/cancel",  # noqa
         },
-        "self_html": f"https://127.0.0.1:5000/communities/{community_slug}/invitations/{request_id}",  # noqa
+        "self_html": f"https://127.0.0.1:5000/communities/{community_slug}/requests/{request_id}",  # noqa
     }
     assert expected_links == hit["links"]
 

--- a/tests/members/test_members_resource.py
+++ b/tests/members/test_members_resource.py
@@ -131,6 +131,27 @@ def test_invite_deny(client, headers, community_id, new_user, new_user_data, db)
     assert r.status_code == 403
 
 
+def test_invite_duplicate(
+    client,
+    community_id,
+    db,
+    headers,
+    new_user_data,
+    owner,
+):
+    client = owner.login(client)
+    r = client.post(
+        f"/communities/{community_id}/invitations", headers=headers, json=new_user_data
+    )
+    assert 204 == r.status_code
+
+    r = client.post(
+        f"/communities/{community_id}/invitations", headers=headers, json=new_user_data
+    )
+    assert 400 == r.status_code
+    assert r.json["message"] is not None
+
+
 #
 # Update
 #
@@ -529,10 +550,37 @@ def test_put_update_membership_requests(
 
 
 def test_error_handling_for_membership_requests(
-    client, headers, community_id, owner, new_user_data, db
+    clean_index,
+    client,
+    community_open_to_membership_requests,
+    create_user,
+    db,
+    headers,
+    owner,
 ):
-    # TODO: Implement me!
-    # error handling registered
-    #   - permission handling registered
-    #   - duplicate handling registered
-    assert True
+    community_id = str(community_open_to_membership_requests._record.id)
+
+    # Case - denied because of permission
+    r = client.post(
+        f"/communities/{community_id}/membership-requests",
+        headers=headers,
+        json={"message": "Can I join the club?"},
+    )
+    assert 403 == r.status_code
+
+    # Case - denied because duplicate (already added, invited or requeested)
+    user = create_user({"email": "user_foo@example.org", "username": "user_foo"})
+    client = user.login(client)
+    r = client.post(
+        f"/communities/{community_id}/membership-requests",
+        headers=headers,
+        json={"message": "Can I join the club?"},
+    )
+    assert 201 == r.status_code
+    r = client.post(
+        f"/communities/{community_id}/membership-requests",
+        headers=headers,
+        json={"message": "Can I join the club again?"},
+    )
+    assert 400 == r.status_code
+    assert r.json["message"] is not None

--- a/tests/members/test_members_services.py
+++ b/tests/members/test_members_services.py
@@ -309,6 +309,45 @@ def test_invite_view_request(
     assert hits["hits"][0]["payload"]["content"] == "Welcome to the club!"
 
 
+def test_invite_multiple_members_with_one_already_invited(
+    clean_index,
+    community,
+    create_user,
+    db,
+    member_service,
+    members,
+    owner,
+):
+    res = member_service.search_invitations(
+        owner.identity, community._record.id
+    ).to_dict()
+    total_before = res["hits"]["total"]
+    user_1 = create_user(data={"email": "user_1@example.org", "username": "user_1"})
+    user_2 = create_user(data={"email": "user_2@example.org", "username": "user_2"})
+    data = {
+        "members": [
+            {"type": "user", "id": str(user_1.id)},
+            {"type": "user", "id": str(members["reader"].id)},
+            {"type": "user", "id": str(user_2.id)},
+        ],
+        "role": "reader",
+    }
+
+    pytest.raises(
+        AlreadyMemberError,
+        member_service.invite,
+        owner.identity,
+        community._record.id,
+        data,
+    )
+
+    # *No* invitations should go through if one is problematic
+    res = member_service.search_invitations(
+        owner.identity, community._record.id
+    ).to_dict()
+    assert total_before == res["hits"]["total"]
+
+
 #
 # Search and read members
 #

--- a/tests/members/test_members_services.py
+++ b/tests/members/test_members_services.py
@@ -342,6 +342,7 @@ def test_invite_multiple_members_with_one_already_invited(
     )
 
     # *No* invitations should go through if one is problematic
+    Member.index.refresh()
     res = member_service.search_invitations(
         owner.identity, community._record.id
     ).to_dict()


### PR DESCRIPTION
This PR is # 5 in a series of PRs to revive and merge the "Request to join a community as a user" feature. This PR covers the frontend on the community side and is complemented by  https://github.com/inveniosoftware/invenio-app-rdm/pull/3442 in invenio-app-rdm (requester side already covered).

**Out of bounds/future PRs**: notifications and expiry 

**Related PRs**
- Draft RFC here: https://github.com/inveniosoftware/rfcs/pull/111 .
- Invenio-app-rdm PR: https://github.com/inveniosoftware/invenio-app-rdm/pull/3442
- Abandonned original PR: https://github.com/inveniosoftware/invenio-communities/pull/1175

**Current commits**
- **feat(mshp-req): display membership requests on community dashboard**
- **feat(inv): cancel invitations from community invitations search**
- **feat: generalize error message for AlreadyMemberError**
- **feat(inv): use backend self_html for frontend invitation link**

**Screenshots**
Most up-to-date ones are on the RFC linked above.

*Membership Requests search*
<img width="1649" height="466" alt="membership_requests_on_membership_requests_section_on_community_members_tab" src="https://github.com/user-attachments/assets/538b2c70-f404-47c6-a26b-66cbeb499ade" />

*Accepted Membership request page*
<img width="1618" height="931" alt="discussion_in_community_page" src="https://github.com/user-attachments/assets/4bbea072-2bec-4a6c-9b17-68eeb7a3f687" />

*Ability to cancel invitations from UI!*
<img width="1649" height="455" alt="invitations_listing_with_cancel_manager_perspective" src="https://github.com/user-attachments/assets/10faf831-b81a-494d-b684-c8f1706e006c" />
