### PR TITLE
fix(community-themes): only request theme CSS for themed communities

### DIFF
--- a/invenio_communities/templates/semantic-ui/invenio_communities/base.html
+++ b/invenio_communities/templates/semantic-ui/invenio_communities/base.html
@@ -11,7 +11,10 @@
 
 {%- block css %}
 {{ super() }}
-{% if community %}
-<link rel="stylesheet" type="text/css" href="/communities/{{community.slug}}/community-theme-{{ community.revision_id }}.css">
+{% if community and community.theme %}
+<link
+  rel="stylesheet"
+  type="text/css"
+  href="{{ invenio_url_for('invenio_communities.community_theme_css_config', pid_value=community.slug, revision=community.revision_id) }}">
 {% endif %}
 {%- endblock css %}


### PR DESCRIPTION
Previously, the community base template *always* requested the community theme CSS, regardless of the community actually being themed or not.
For un-themed communities, this resulted in unnecessary requests with zero-length responses.

This PR requests community theme CSS only if the community has a theme set.