### PR TITLE
mshp-req expiry, notifications and final fixes/improvements

### DIFF
--- a/invenio_communities/assets/semantic-ui/js/invenio_communities/members/components/bulk_actions/SelectedMembers.js
+++ b/invenio_communities/assets/semantic-ui/js/invenio_communities/members/components/bulk_actions/SelectedMembers.js
@@ -24,7 +24,7 @@ export class SelectedMembers extends Component {
     const { selectedMembers, headerText } = this.props;
 
     return !_isEmpty(selectedMembers) ? (
-      <Segment className="selected-members-header mb-20 mr-20">
+      <Segment className="selected-members-header mb-20">
         {Object.entries(selectedMembers).map(([memberId, member]) => (
           <Button
             key={memberId}

--- a/invenio_communities/assets/semantic-ui/js/invenio_communities/members/invitations/invitationsModal/InvitationsMembersModal.js
+++ b/invenio_communities/assets/semantic-ui/js/invenio_communities/members/invitations/invitationsModal/InvitationsMembersModal.js
@@ -131,7 +131,7 @@ export class InvitationsMembersModal extends Component {
             doneButtonTipType={i18next.t("users")}
             existingEntities={existingIds}
             existingEntitiesDescription={i18next.t(
-              "Already a member or invitation pending"
+              "Already a member or pending a decision"
             )}
             searchBarPlaceholder={i18next.t(
               "Search by full name, username or email (if publicly visible)"

--- a/invenio_communities/assets/semantic-ui/js/invenio_communities/members/member_requests/MemberRequestsSearchBarElement.js
+++ b/invenio_communities/assets/semantic-ui/js/invenio_communities/members/member_requests/MemberRequestsSearchBarElement.js
@@ -7,6 +7,7 @@
  * Invenio is free software; you can redistribute it and/or modify it
  * under the terms of the MIT License; see LICENSE file for more details.
  */
+
 import React from "react";
 import { Input } from "semantic-ui-react";
 import { i18next } from "@translations/invenio_communities/i18next";

--- a/invenio_communities/assets/semantic-ui/js/invenio_communities/members/member_requests/MemberRequestsSearchBarElement.js
+++ b/invenio_communities/assets/semantic-ui/js/invenio_communities/members/member_requests/MemberRequestsSearchBarElement.js
@@ -7,7 +7,6 @@
  * Invenio is free software; you can redistribute it and/or modify it
  * under the terms of the MIT License; see LICENSE file for more details.
  */
-
 import React from "react";
 import { Input } from "semantic-ui-react";
 import { i18next } from "@translations/invenio_communities/i18next";

--- a/invenio_communities/assets/semantic-ui/js/invenio_communities/members/membership_requests/MembershipRequestsEmptyResults.js
+++ b/invenio_communities/assets/semantic-ui/js/invenio_communities/members/membership_requests/MembershipRequestsEmptyResults.js
@@ -1,9 +1,8 @@
 /*
- * This file is part of Invenio.
  *
  * Copyright (C) 2026 Northwestern University.
  *
- * Invenio is free software; you can redistribute it and/or modify it
+ * Invenio-communities is free software; you can redistribute it and/or modify it
  * under the terms of the MIT License; see LICENSE file for more details.
  */
 

--- a/invenio_communities/config.py
+++ b/invenio_communities/config.py
@@ -208,7 +208,7 @@ COMMUNITIES_MEMBERS_FACETS = {
 """Available facets defined for this module."""
 
 COMMUNITIES_INVITATIONS_SEARCH = {
-    "facets": ["type", "status"],  # what is type?
+    "facets": ["type", "status"],
     "sort": ["bestmatch", "name", "newest", "oldest"],
 }
 """Community invitations search configuration (i.e list of community invitations)"""

--- a/invenio_communities/config.py
+++ b/invenio_communities/config.py
@@ -208,7 +208,7 @@ COMMUNITIES_MEMBERS_FACETS = {
 """Available facets defined for this module."""
 
 COMMUNITIES_INVITATIONS_SEARCH = {
-    "facets": ["type", "status"],
+    "facets": ["type", "status"],  # what is type?
     "sort": ["bestmatch", "name", "newest", "oldest"],
 }
 """Community invitations search configuration (i.e list of community invitations)"""
@@ -234,13 +234,13 @@ COMMUNITIES_INVITATIONS_SORT_OPTIONS = {
 """Definitions of available record sort options."""
 
 COMMUNITIES_INVITATIONS_EXPIRES_IN = timedelta(days=30)
-""""Default amount of time before an invitation expires."""
+"""Default amount of time before an invitation expires."""
 
 COMMUNITIES_MEMBERSHIP_REQUESTS_SEARCH = {
     "facets": ["role", "status"],
     "sort": ["bestmatch", "name", "newest", "oldest"],
 }
-""""Community membership requests search configuration."""
+"""Community membership requests search configuration."""
 
 COMMUNITIES_MEMBERSHIP_REQUESTS_FACETS = {
     "role": {
@@ -257,6 +257,9 @@ COMMUNITIES_MEMBERSHIP_REQUESTS_FACETS = {
     },
 }
 """Available facets for membership requests."""
+
+COMMUNITIES_MEMBERSHIP_REQUESTS_EXPIRES_IN = timedelta(days=30)
+"""Default amount of time before a membership request expires."""
 
 COMMUNITIES_LOGO_MAX_FILE_SIZE = 10**6
 """Community logo size quota, in bytes."""

--- a/invenio_communities/members/services/links.py
+++ b/invenio_communities/members/services/links.py
@@ -7,13 +7,10 @@
 
 """Members Service links."""
 
-from collections import namedtuple
-
 from invenio_records_resources.services.base.links import (
     EndpointLink,
 )
 from invenio_requests.proxies import current_request_type_registry
-from invenio_requests.services.links import RequestTypeDependentEndpointLink
 
 from .request import CommunityInvitation, MembershipRequestRequestType
 

--- a/invenio_communities/members/services/links.py
+++ b/invenio_communities/members/services/links.py
@@ -7,10 +7,13 @@
 
 """Members Service links."""
 
+from collections import namedtuple
+
 from invenio_records_resources.services.base.links import (
     EndpointLink,
 )
 from invenio_requests.proxies import current_request_type_registry
+from invenio_requests.services.links import RequestTypeDependentEndpointLink
 
 from .request import CommunityInvitation, MembershipRequestRequestType
 

--- a/invenio_communities/members/services/request.py
+++ b/invenio_communities/members/services/request.py
@@ -34,67 +34,6 @@ def service():
     """Service."""
     return current_communities.service.members
 
-#
-# Request
-#
-
-
-def is_request_created_by_current_user(obj, vars):
-    """Is created by current user.
-
-    Because this is called in the context of a RequestType, the received obj
-    can be a Request or RequestEvent, so better to trust the vars content.
-
-    :param obj: api.Request|api.RequestEvent
-    :param vars: dict: context variables w/ keys:
-        "permission_policy_cls" for api.Request
-        "identity"
-        "request"
-        "request_type"
-    """
-    request = vars["request"]
-    id_creator = str(request.created_by.reference_dict.get("user"))
-    id_identity = str(vars["identity"].id)
-    return id_identity == id_creator
-
-
-def update_vars_for_user_dashboard_request_view(obj, vars):
-    """Update vars.
-
-    Because this is called in the context of a RequestType, the received obj
-    can be a Request or RequestEvent so better to trust the vars content.
-
-    :param obj: api.Request|api.RequestEvent
-    :param vars: dict: context variables w/ keys:
-        "permission_policy_cls" for api.Request
-        "identity"
-        "request"
-        "request_type"
-    """
-    vars.update(request_pid_value=str(vars["request"].id))
-
-
-def update_vars_for_community_dashboard_request_view(obj, vars):
-    """Update vars.
-
-    Because this is called in the context of a RequestType, the received obj
-    can be a Request or RequestEvent so better to trust the vars content.
-
-    :param obj: api.Request|api.RequestEvent
-    :param vars: dict: context variables w/ keys:
-        "permission_policy_cls" for api.Request
-        "identity"
-        "request"
-        "request_type"
-    """
-    request = vars["request"]
-    # The topic holds a CommunityPKProxy
-    slug = get_cached_community_slug(request.topic.reference_dict["community"])
-    vars.update(
-        pid_value=slug,
-        request_pid_value=request.id,
-    )
-
 
 #
 # Request

--- a/invenio_communities/members/services/request.py
+++ b/invenio_communities/members/services/request.py
@@ -20,6 +20,10 @@ from invenio_communities.notifications.builders import (
     CommunityInvitationCancelNotificationBuilder,
     CommunityInvitationDeclineNotificationBuilder,
     CommunityInvitationExpireNotificationBuilder,
+    CommunityMembershipRequestAcceptedNotificationBuilder,
+    CommunityMembershipRequestCancelledNotificationBuilder,
+    CommunityMembershipRequestDeclinedNotificationBuilder,
+    CommunityMembershipRequestExpiredNotificationBuilder,
 )
 
 from ...communities.services.service import get_cached_community_slug
@@ -29,6 +33,67 @@ from ...proxies import current_communities
 def service():
     """Service."""
     return current_communities.service.members
+
+#
+# Request
+#
+
+
+def is_request_created_by_current_user(obj, vars):
+    """Is created by current user.
+
+    Because this is called in the context of a RequestType, the received obj
+    can be a Request or RequestEvent, so better to trust the vars content.
+
+    :param obj: api.Request|api.RequestEvent
+    :param vars: dict: context variables w/ keys:
+        "permission_policy_cls" for api.Request
+        "identity"
+        "request"
+        "request_type"
+    """
+    request = vars["request"]
+    id_creator = str(request.created_by.reference_dict.get("user"))
+    id_identity = str(vars["identity"].id)
+    return id_identity == id_creator
+
+
+def update_vars_for_user_dashboard_request_view(obj, vars):
+    """Update vars.
+
+    Because this is called in the context of a RequestType, the received obj
+    can be a Request or RequestEvent so better to trust the vars content.
+
+    :param obj: api.Request|api.RequestEvent
+    :param vars: dict: context variables w/ keys:
+        "permission_policy_cls" for api.Request
+        "identity"
+        "request"
+        "request_type"
+    """
+    vars.update(request_pid_value=str(vars["request"].id))
+
+
+def update_vars_for_community_dashboard_request_view(obj, vars):
+    """Update vars.
+
+    Because this is called in the context of a RequestType, the received obj
+    can be a Request or RequestEvent so better to trust the vars content.
+
+    :param obj: api.Request|api.RequestEvent
+    :param vars: dict: context variables w/ keys:
+        "permission_policy_cls" for api.Request
+        "identity"
+        "request"
+        "request_type"
+    """
+    request = vars["request"]
+    # The topic holds a CommunityPKProxy
+    slug = get_cached_community_slug(request.topic.reference_dict["community"])
+    vars.update(
+        pid_value=slug,
+        request_pid_value=request.id,
+    )
 
 
 #
@@ -220,16 +285,13 @@ class AcceptMembershipRequestAction(actions.AcceptAction):
     def execute(self, identity, uow):
         """Execute action."""
         service().accept_member_request(system_identity, self.request.id, uow=uow)
-        # TODO: notifications for accept
-        # uow.register(
-        #     NotificationOp(
-        #         (
-        #             CommunityMembershipRequestAcceptNotificationBuilder.build(
-        #                 self.request
-        #             )
-        #         )
-        #     )
-        # )
+        uow.register(
+            NotificationOp(
+                CommunityMembershipRequestAcceptedNotificationBuilder.build(
+                    self.request
+                )
+            )
+        )
         super().execute(identity, uow)
 
 
@@ -239,7 +301,13 @@ class CancelMembershipRequestAction(actions.CancelAction):
     def execute(self, identity, uow):
         """Execute action."""
         service().close_member_request(system_identity, self.request.id, uow=uow)
-        # TODO: Investigate notifications
+        uow.register(
+            NotificationOp(
+                CommunityMembershipRequestCancelledNotificationBuilder.build(
+                    self.request
+                )
+            )
+        )
         super().execute(identity, uow)
 
 
@@ -249,15 +317,27 @@ class DeclineMembershipRequestAction(actions.DeclineAction):
     def execute(self, identity, uow):
         """Execute action."""
         service().close_member_request(system_identity, self.request.id, uow=uow)
-        # TODO: Notification for declining
-        # uow.register(
-        #     NotificationOp(
-        #         (
-        #             CommunityMembershipRequestDeclineNotificationBuilder
-        #             .build(self.request)
-        #         )
-        #     )
-        # )
+        uow.register(
+            NotificationOp(
+                CommunityMembershipRequestDeclinedNotificationBuilder.build(
+                    self.request
+                )
+            )
+        )
+        super().execute(identity, uow)
+
+
+class ExpireMembershipRequestAction(actions.ExpireAction):
+    """Expire action."""
+
+    def execute(self, identity, uow):
+        """Execute action."""
+        service().close_member_request(system_identity, self.request.id, uow=uow)
+        uow.register(
+            NotificationOp(
+                CommunityMembershipRequestExpiredNotificationBuilder.build(self.request)
+            )
+        )
         super().execute(identity, uow)
 
 
@@ -270,9 +350,10 @@ class MembershipRequestRequestType(RequestType):
     create_action = "create"
     available_actions = {
         "accept": AcceptMembershipRequestAction,
-        "create": actions.CreateAndSubmitAction,
         "cancel": CancelMembershipRequestAction,
+        "create": actions.CreateAndSubmitAction,
         "decline": DeclineMembershipRequestAction,
+        "expire": ExpireMembershipRequestAction,
     }
 
     creator_can_be_none = False
@@ -294,8 +375,7 @@ class MembershipRequestRequestType(RequestType):
     links_item = {
         # This EndpointLink selection logic is better than existing logic for
         # other RequestTypes' self_html, bc it points to right place depending
-        # on current user. But it may need further improvements down the road
-        # to also depend on the state of the request.
+        # on current user.
         "self_html": ConditionalLink(
             cond=is_request_created_by_current_user,
             # if_ -> then_ : change when ConditionalLink is updated

--- a/invenio_communities/members/services/service.py
+++ b/invenio_communities/members/services/service.py
@@ -34,7 +34,10 @@ from marshmallow import ValidationError
 from sqlalchemy.exc import IntegrityError
 from werkzeug.local import LocalProxy
 
-from ...notifications.builders import CommunityInvitationSubmittedNotificationBuilder
+from ...notifications.builders import (
+    CommunityInvitationSubmittedNotificationBuilder,
+    CommunityMembershipRequestSubmittedNotificationBuilder,
+)
 from ...proxies import current_roles
 from ..errors import AlreadyMemberError, InvalidMemberError
 from ..records.api import ArchivedMemberRequest, MemberMixin
@@ -877,16 +880,15 @@ class MemberService(RecordService):
         }
         request_item = current_requests_service.create(
             identity,
-            data={
-                "title": title,
-                # "description": description,
-            },
+            data={"title": title},
             request_type=MembershipRequestRequestType,
-            receiver=community,
             creator={"user": str(identity.user.id)},
-            topic=community,  # user instead?
-            # TODO: Consider expiration
-            # expires_at=invite_expires_at(),
+            topic=community,
+            receiver=community,
+            expires_at=(
+                datetime.now(timezone.utc)
+                + current_app.config["COMMUNITIES_MEMBERSHIP_REQUESTS_EXPIRES_IN"]
+            ),
             uow=uow,
         )
 
@@ -901,23 +903,23 @@ class MemberService(RecordService):
                 notify=False,
             )
 
-        # TODO: Add notification mechanism
-        # uow.register(
-        #     NotificationOp(
-        #         MembershipRequestSubmittedNotificationBuilder.build(
-        #             request=request_item._request,
-        #             # explicit string conversion to get the value of LazyText
-        #             role=str(role.title),
-        #             message=message,
-        #         )
-        #     )
-        # )
+        role = current_roles["reader"]
+
+        uow.register(
+            NotificationOp(
+                CommunityMembershipRequestSubmittedNotificationBuilder.build(
+                    request=request_item._request,
+                    role=role.name,
+                    message=message,
+                )
+            )
+        )
 
         # Create an inactive member entry linked to the request.
         self._add_factory(
             identity,
             community=community,
-            role=current_roles["reader"],
+            role=role,
             visible=False,
             member={"type": "user", "id": str(identity.user.id)},
             message=message,

--- a/invenio_communities/notifications/builders.py
+++ b/invenio_communities/notifications/builders.py
@@ -20,7 +20,7 @@ from invenio_communities.notifications.generators import CommunityMembersRecipie
 
 
 class BaseNotificationBuilder(NotificationBuilder):
-    """Base notification builder for community invitation action."""
+    """Base notification builder for community notification."""
 
     context = [
         EntityResolve(key="request"),
@@ -151,6 +151,99 @@ class CommunityInvitationExpireNotificationBuilder(
     recipients = [
         CommunityMembersRecipient(key="request.created_by", roles=["owner", "manager"]),
         UserRecipient(key="request.receiver"),
+    ]
+
+
+class CommunityMembershipRequestNotificationBuilder(BaseNotificationBuilder):
+    """Base notification builder for community membership-request action."""
+
+    type = "community-membership-request"
+
+    @classmethod
+    def build(cls, request, message=None):
+        """Build notification with request context."""
+        return Notification(
+            type=cls.type,
+            context={
+                "request": EntityResolverRegistry.reference_entity(request),
+            },
+        )
+
+
+class CommunityMembershipRequestSubmittedNotificationBuilder(
+    CommunityMembershipRequestNotificationBuilder
+):
+    """Notification builder for membership request submitted."""
+
+    type = f"{CommunityMembershipRequestNotificationBuilder.type}.submit"
+
+    @classmethod
+    def build(cls, request, role, message=None):
+        """Build notification with request context.
+
+        :param request: api.Request
+        :param role: string
+        :param message: string
+        """
+        return Notification(
+            type=cls.type,
+            context={
+                "request": EntityResolverRegistry.reference_entity(request),
+                "role": role,
+                "message": message,
+            },
+        )
+
+    recipients = [
+        CommunityMembersRecipient(key="request.receiver", roles=["owner", "manager"]),
+    ]
+
+
+class CommunityMembershipRequestCancelledNotificationBuilder(
+    CommunityMembershipRequestNotificationBuilder
+):
+    """Notification builder for membership request cancelled."""
+
+    type = f"{CommunityMembershipRequestNotificationBuilder.type}.cancel"
+    recipients = [
+        CommunityMembersRecipient(key="request.receiver", roles=["owner", "manager"]),
+    ]
+
+
+class CommunityMembershipRequestAcceptedNotificationBuilder(
+    CommunityMembershipRequestNotificationBuilder
+):
+    """Notification builder for membership request accepted."""
+
+    type = f"{CommunityMembershipRequestNotificationBuilder.type}.accept"
+
+    recipients = [
+        UserRecipient(key="request.created_by"),
+    ]
+
+
+class CommunityMembershipRequestDeclinedNotificationBuilder(
+    CommunityMembershipRequestNotificationBuilder
+):
+    """Notification builder for membership request declined."""
+
+    type = f"{CommunityMembershipRequestNotificationBuilder.type}.decline"
+
+    recipients = [
+        UserRecipient(key="request.created_by"),
+    ]
+
+
+class CommunityMembershipRequestExpiredNotificationBuilder(
+    CommunityMembershipRequestNotificationBuilder
+):
+    """Notification builder for membership request expired."""
+
+    type = f"{CommunityMembershipRequestNotificationBuilder.type}.expire"
+
+    recipients = [
+        UserRecipient(key="request.created_by"),
+        CommunityMembersRecipient(key="request.receiver", roles=["owner", "manager"]),
     ]
 
 

--- a/invenio_communities/permissions.py
+++ b/invenio_communities/permissions.py
@@ -166,7 +166,9 @@ class CommunityPermissionPolicy(BasePermissionPolicy):
     # is disallowed if the app config or community setting turned the feature off.
     can_request_membership = [
         IfCommunityAllowsMembershipRequests(
-            then_=[AuthenticatedUserButNotCommunityMember()], else_=[Disable()]
+            # TODO: Refactor to add NotCommunityCandidate()
+            then_=[AuthenticatedUserButNotCommunityMember()],
+            else_=[Disable()],
         )
     ]
     # For search, it might have been useful to let any non-UI cases, but that is too

--- a/invenio_communities/templates/semantic-ui/invenio_communities/details/header.html
+++ b/invenio_communities/templates/semantic-ui/invenio_communities/details/header.html
@@ -19,27 +19,24 @@
   {# Ths conditionals try hard to reduce the need for a DB hit #}
   {% if config.COMMUNITIES_ALLOW_MEMBERSHIP_REQUESTS %}
     {% if community_ui["access"]["member_policy"] == "open" %}
-      {# The below permission check includes the above checks among other checks, so
-         it was not enough on its own to prevent a large swath of cases where the DB
-         could be hit.
+      {# TODO: Create a new temporary and off-the-books community role for pending members and
+               leverage it in permission checks to forego the need to hit the database every time.
       #}
-      {% if permissions.can_request_membership %}
+      {% set request_id_of_pending_member = get_request_id_of_pending_member(g.identity, community_ui["id"]) %}
+      {# None if no pending membership or invitation request #}
+      {% if request_id_of_pending_member %}
+        <a href="{{ url_for('invenio_app_rdm_requests.user_dashboard_request_view', request_pid_value=request_id_of_pending_member) }}"
+          class="ui button labeled icon rel-mt-1 theme-secondary">
+          <i class="sign-in icon" aria-hidden="true"></i>
+          {{ _("Membership discussion") }}
+        </a>
+      {% elif permissions.can_request_membership %}
         <div
           id="request-membership-app"
           data-community='{{ community_ui | tojson }}'
           class="display-inline-block"
         >
         </div>
-      {% else %}
-        {% set request_id_of_pending_member = get_request_id_of_pending_member(g.identity, community_ui["id"]) %}
-        {# None if no pending membership or invitation request #}
-        {% if request_id_of_pending_member %}
-          <a href="{{ url_for('invenio_app_rdm_requests.user_dashboard_request_view', request_pid_value=request_id_of_pending_member) }}"
-            class="ui button labeled icon rel-mt-1 theme-secondary">
-            <i class="sign-in icon" aria-hidden="true"></i>
-            {{ _("Membership discussion") }}
-          </a>
-        {% endif %}
       {% endif %}
     {% endif %}
   {% endif %}

--- a/invenio_communities/templates/semantic-ui/invenio_notifications/community-invitation.accept.jinja
+++ b/invenio_communities/templates/semantic-ui/invenio_notifications/community-invitation.accept.jinja
@@ -13,7 +13,8 @@
 {% set community_title = community.metadata.title %}
 {% set receiver_name = receiver.username or receiver.profile.full_name %}
 {# This notification is sent to the community owners/managers so community link used #}
-{% set request_link = invenio_url_for("invenio_app_rdm_requests.community_dashboard_membership_request_view", pid_value=community.slug, request_pid_value=request.id) %}
+{# TODO: use community_dashboard_invitation_view endpoint when app-rdm defines it #}
+{% set request_link = invenio_url_for("invenio_app_rdm_requests.community_dashboard_request_view", pid_value=community.slug, request_pid_value=invitation_request.id) %}
 {% set account_settings_link = invenio_url_for("invenio_notifications_settings.index") %}
 
 

--- a/invenio_communities/templates/semantic-ui/invenio_notifications/community-invitation.accept.jinja
+++ b/invenio_communities/templates/semantic-ui/invenio_notifications/community-invitation.accept.jinja
@@ -1,17 +1,21 @@
+{# -*- coding: utf-8 -*-
+
+  Copyright (C) 2024 CERN.
+  Copyright (C) 2026 Northwestern University.
+
+  invenio-communities is free software; you can redistribute it and/or modify it
+  under the terms of the MIT License; see LICENSE file for more details.
+#}
 {% set invitation_request = notification.context.request %}
 {% set receiver = invitation_request.receiver %}
 {% set community = invitation_request.created_by %}
-{% set request_id = invitation_request.id %}
 {% set message = notification.context.message | safe if notification.context.message else '' %}
 {% set community_title = community.metadata.title %}
 {% set receiver_name = receiver.username or receiver.profile.full_name %}
-
-{# TODO: use request.links.self_html when issue issue is resolved: https://github.com/inveniosoftware/invenio-rdm-records/issues/1327 #}
-{% set request_link = "{ui}/me/requests/{id}".format(
-    ui=config.SITE_UI_URL, id=request_id
-    )
-%}
+{# This notification is sent to the community owners/managers so community link used #}
+{% set request_link = invenio_url_for("invenio_app_rdm_requests.community_dashboard_membership_request_view", pid_value=community.slug, request_pid_value=request.id) %}
 {% set account_settings_link = invenio_url_for("invenio_notifications_settings.index") %}
+
 
 {%- block subject -%}
    {{ _("✅ @{user_name} accepted the invitation to join community '{community_title}'.").format(user_name=receiver_name, community_title=community_title) }}

--- a/invenio_communities/templates/semantic-ui/invenio_notifications/community-invitation.cancel.jinja
+++ b/invenio_communities/templates/semantic-ui/invenio_notifications/community-invitation.cancel.jinja
@@ -1,17 +1,21 @@
+{# -*- coding: utf-8 -*-
+
+  Copyright (C) 2024 CERN.
+  Copyright (C) 2026 Northwestern University.
+
+  invenio-communities is free software; you can redistribute it and/or modify it
+  under the terms of the MIT License; see LICENSE file for more details.
+#}
 {% set invitation_request = notification.context.request %}
 {% set receiver = invitation_request.receiver %}
 {% set community = invitation_request.created_by %}
-{% set request_id = invitation_request.id %}
 {% set message = notification.context.message | safe if notification.context.message else '' %}
 {% set community_title = community.metadata.title %}
 {% set receiver_name = receiver.username or receiver.profile.full_name %}
-
-{# TODO: use request.links.self_html when issue issue is resolved: https://github.com/inveniosoftware/invenio-rdm-records/issues/1327 #}
-{% set request_link = "{ui}/me/requests/{id}".format(
-    ui=config.SITE_UI_URL, id=request_id
-    )
-%}
+{# This notification is sent to the invitee so user link used #}
+{% set request_link = invenio_url_for("invenio_app_rdm_requests.user_dashboard_request_view", request_pid_value=invitation_request.id) %}
 {% set account_settings_link = invenio_url_for("invenio_notifications_settings.index") %}
+
 
 {%- block subject -%}
    {{ _("❌ Community member invitation cancelled for @{user_name}").format(user_name=receiver_name) }}

--- a/invenio_communities/templates/semantic-ui/invenio_notifications/community-invitation.decline.jinja
+++ b/invenio_communities/templates/semantic-ui/invenio_notifications/community-invitation.decline.jinja
@@ -13,7 +13,7 @@
 {% set community_title = community.metadata.title %}
 {% set receiver_name = receiver.username or receiver.profile.full_name %}
 {# This email is sent to the community owners/managers so community link used #}
-{% set request_link = invenio_url_for("invenio_app_rdm_requests.community_dashboard_membership_request_view", pid_value=community.slug, request_pid_value=request.id) %}
+{% set request_link = invenio_url_for("invenio_app_rdm_requests.community_dashboard_request_view", pid_value=community.slug, request_pid_value=invitation_request.id) %}
 {% set account_settings_link = invenio_url_for("invenio_notifications_settings.index") %}
 
 

--- a/invenio_communities/templates/semantic-ui/invenio_notifications/community-invitation.decline.jinja
+++ b/invenio_communities/templates/semantic-ui/invenio_notifications/community-invitation.decline.jinja
@@ -1,17 +1,21 @@
+{# -*- coding: utf-8 -*-
+
+  Copyright (C) 2024 CERN.
+  Copyright (C) 2026 Northwestern University.
+
+  invenio-communities is free software; you can redistribute it and/or modify it
+  under the terms of the MIT License; see LICENSE file for more details.
+#}
 {% set invitation_request = notification.context.request %}
 {% set receiver = invitation_request.receiver %}
 {% set community = invitation_request.created_by %}
-{% set request_id = invitation_request.id %}
 {% set message = notification.context.message | safe if notification.context.message else '' %}
 {% set community_title = community.metadata.title %}
 {% set receiver_name = receiver.username or receiver.profile.full_name %}
-
-{# TODO: use request.links.self_html when issue issue is resolved: https://github.com/inveniosoftware/invenio-rdm-records/issues/1327 #}
-{% set request_link = "{ui}/me/requests/{id}".format(
-    ui=config.SITE_UI_URL, id=request_id
-    )
-%}
+{# This email is sent to the community owners/managers so community link used #}
+{% set request_link = invenio_url_for("invenio_app_rdm_requests.community_dashboard_membership_request_view", pid_value=community.slug, request_pid_value=request.id) %}
 {% set account_settings_link = invenio_url_for("invenio_notifications_settings.index") %}
+
 
 {%- block subject -%}
   {{ _("⛔️ @{user_name} declined the invitation to join '{community_title}'").format(user_name=receiver_name, community_title=community_title) }}

--- a/invenio_communities/templates/semantic-ui/invenio_notifications/community-invitation.expire.jinja
+++ b/invenio_communities/templates/semantic-ui/invenio_notifications/community-invitation.expire.jinja
@@ -16,19 +16,19 @@
 {% set request_link = (
   invenio_url_for("invenio_app_rdm_requests.user_dashboard_request_view", request_pid_value=invitation_request.id)
   if recipient_is_receiver else
-  invenio_url_for("invenio_app_rdm_requests.community_dashboard_membership_request_view", pid_value=community.slug, request_pid_value=invitation_request.id)
+  invenio_url_for("invenio_app_rdm_requests.community_dashboard_request_view", pid_value=community.slug, request_pid_value=invitation_request.id)
 ) %}
 {% set account_settings_link = invenio_url_for("invenio_notifications_settings.index") %}
 
 
 {%- block subject -%}
-  {{ _("⌛️ The invitation for @{user_name} to join community '{community_title}' expired").format(user_name=receiver_name, community_title=community_title) }}
+  {{ _("⌛️ The invitation for '@{user_name}' to join community '{community_title}' expired").format(user_name=receiver_name, community_title=community_title) }}
 {%- endblock subject -%}
 
 {%- block html_body -%}
 <table style="font-family:'Lato',Helvetica,Arial,sans-serif;border-spacing:15px">
     <tr>
-        <td>{{ _("The invitation for '@{user_name}' to join community '{community_title}' has expired.").format(user_name=receiver_name, community_title=community_title) }}</td>
+        <td>{{ _("The invitation for '@{user_name}' to join community '{community_title}' expired").format(user_name=receiver_name, community_title=community_title) }}.</td>
     </tr>
     <tr>
         <td><a href="{{ request_link }}" class="button">{{ _("Check out the invitation")}}</a></td>
@@ -43,14 +43,14 @@
 {%- endblock html_body %}
 
 {%- block plain_body -%}
-{{ _("The invitation for @{user_name} to join community '{community_title}' has expired.").format(user_name=receiver_name, community_title=community_title) }}
+{{ _("The invitation for '@{user_name}' to join community '{community_title}' expired.").format(user_name=receiver_name, community_title=community_title) }}
 
 {{ _("Check out the invitation:") }} {{ request_link }}
 {%- endblock plain_body %}
 
 {# Markdown for Slack/Mattermost/chat #}
 {%- block md_body -%}
-{{ _("The invitation for *@{user_name}* to join community *{community_title}* has expired.").format(user_name=receiver_name, community_title=community_title) }}
+{{ _("The invitation for *@{user_name}* to join community *{community_title}* expired.").format(user_name=receiver_name, community_title=community_title) }}
 
 [{{ _("Check out the invitation") }}]({{ request_link }})
 {%- endblock md_body %}

--- a/invenio_communities/templates/semantic-ui/invenio_notifications/community-invitation.expire.jinja
+++ b/invenio_communities/templates/semantic-ui/invenio_notifications/community-invitation.expire.jinja
@@ -1,17 +1,25 @@
+{# -*- coding: utf-8 -*-
+
+  Copyright (C) 2024 CERN.
+  Copyright (C) 2026 Northwestern University.
+
+  invenio-communities is free software; you can redistribute it and/or modify it
+  under the terms of the MIT License; see LICENSE file for more details.
+#}
 {% set invitation_request = notification.context.request %}
 {% set receiver = invitation_request.receiver %}
 {% set community = invitation_request.created_by %}
-{% set request_id = invitation_request.id %}
-
 {% set community_title = community.metadata.title %}
 {% set receiver_name = receiver.username or receiver.profile.full_name %}
-
-{# TODO: use request.links.self_html when issue issue is resolved: https://github.com/inveniosoftware/invenio-rdm-records/issues/1327 #}
-{% set request_link = "{ui}/me/requests/{id}".format(
-    ui=config.SITE_UI_URL, id=request_id
-    )
-%}
+{% set recipient_is_receiver = recipient.data.id == receiver.id %}
+{# This notification is sent to all parties so have to check recipient before determining link used #}
+{% set request_link = (
+  invenio_url_for("invenio_app_rdm_requests.user_dashboard_request_view", request_pid_value=invitation_request.id)
+  if recipient_is_receiver else
+  invenio_url_for("invenio_app_rdm_requests.community_dashboard_membership_request_view", pid_value=community.slug, request_pid_value=invitation_request.id)
+) %}
 {% set account_settings_link = invenio_url_for("invenio_notifications_settings.index") %}
+
 
 {%- block subject -%}
   {{ _("⌛️ The invitation for @{user_name} to join community '{community_title}' expired").format(user_name=receiver_name, community_title=community_title) }}

--- a/invenio_communities/templates/semantic-ui/invenio_notifications/community-invitation.submit.jinja
+++ b/invenio_communities/templates/semantic-ui/invenio_notifications/community-invitation.submit.jinja
@@ -1,18 +1,21 @@
+{# -*- coding: utf-8 -*-
+
+  Copyright (C) 2024 CERN.
+  Copyright (C) 2026 Northwestern University.
+
+  invenio-communities is free software; you can redistribute it and/or modify it
+  under the terms of the MIT License; see LICENSE file for more details.
+#}
 {% set invitation_request = notification.context.request %}
 {% set receiver = invitation_request.receiver %}
 {% set community = invitation_request.created_by %}
-{% set request_id = invitation_request.id %}
-
 {% set community_title = community.metadata.title %}
 {% set message = notification.context.message | safe if notification.context.message else '' %}
 {% set role = notification.context.role %}
-
-{# TODO: use request.links.self_html when issue issue is resolved: https://github.com/inveniosoftware/invenio-rdm-records/issues/1327 #}
-{% set request_link = "{ui}/me/requests/{id}".format(
-    ui=config.SITE_UI_URL, id=request_id
-    )
-%}
+{# This notification is sent to the invitee so user link used #}
+{% set request_link = invenio_url_for("invenio_app_rdm_requests.user_dashboard_request_view", request_pid_value=invitation_request.id) %}
 {% set account_settings_link = invenio_url_for("invenio_notifications_settings.index") %}
+
 
 {%- block subject -%}
 {{ _("📬 New invitation to join the community '{community_title}' as '{role}'").format(community_title=community_title, role=role) }}

--- a/invenio_communities/templates/semantic-ui/invenio_notifications/community-membership-request.accept.jinja
+++ b/invenio_communities/templates/semantic-ui/invenio_notifications/community-membership-request.accept.jinja
@@ -11,8 +11,7 @@ under the terms of the MIT License; see LICENSE file for more details.
 {% set community = request.receiver %}
 {% set community_title = community["metadata"]["title"] %}
 {% set role = "role" %}
-{% set request_link = invenio_url_for("invenio_app_rdm_requests.user_dashboard_request_view",
-request_pid_value=request.id) %}
+{% set request_link = invenio_url_for("invenio_app_rdm_requests.user_dashboard_request_view", request_pid_value=request.id) %}
 {% set account_settings_link = invenio_url_for("invenio_notifications_settings.index") %}
 
 

--- a/invenio_communities/templates/semantic-ui/invenio_notifications/community-membership-request.accept.jinja
+++ b/invenio_communities/templates/semantic-ui/invenio_notifications/community-membership-request.accept.jinja
@@ -1,0 +1,60 @@
+{# -*- coding: utf-8 -*-
+
+Copyright (C) 2026 Northwestern University.
+
+invenio-communities is free software; you can redistribute it and/or modify it
+under the terms of the MIT License; see LICENSE file for more details.
+#}
+
+{# Attention: Action-based notifications don't pass `message`, but a separate comment notification is sent so this is fine. #}
+{% set request = notification.context.request %}
+{% set community = request.receiver %}
+{% set community_title = community["metadata"]["title"] %}
+{% set role = "role" %}
+{% set request_link = invenio_url_for("invenio_app_rdm_requests.user_dashboard_request_view",
+request_pid_value=request.id) %}
+{% set account_settings_link = invenio_url_for("invenio_notifications_settings.index") %}
+
+
+{%- block subject -%}
+✅ {{ _("Request to join the community '{community_title}' was accepted").format( community_title=community_title) }}
+{%- endblock subject -%}
+
+
+{%- block html_body -%}
+<table style="font-family:'Lato',Helvetica,Arial,sans-serif;border-spacing:15px">
+  <tr>
+    <td>
+      {{_("The request to join the community '{community_title}' as '{role}' was accepted").format(community_title=community_title, role=role) }}.
+    </td>
+  </tr>
+  <tr>
+    <td><a href="{{ request_link }}" class="button">{{ _("Check out the membership request")}}</a></td>
+  </tr>
+  <tr>
+    <td><strong>_</strong></td>
+  </tr>
+  <tr>
+    <td style="font-size:smaller">{{ _("This is an auto-generated message. To manage notifications, visit your") }} <a href="{{ account_settings_link }}">{{ _("account settings")}}</a>.</td>
+  </tr>
+</table>
+{%- endblock html_body %}
+
+
+{%- block plain_body -%}
+{{ _("The request to join the community '{community_title}' was accepted").format(community_title=community_title) }}.
+
+{{ _("Check out the membership request") }}: {{ request_link }} .
+
+{{ _("This is an auto-generated message. To manage notifications, visit your account settings") }}: {{ account_settings_link }} .
+{%- endblock plain_body %}
+
+
+{# Markdown for Slack/Mattermost/chat #}
+{%- block md_body -%}
+{{ _("The request to join the community *{community_title}* was accepted").format(community_title=community_title) }}.
+
+[{{ _("Check out the membership request") }}]({{ request_link }})
+
+{{ _("This is an auto-generated message. To manage notifications, visit your [account settings]({account_settings_link})").format(account_settings_link=account_settings_link) }}.
+{%- endblock md_body %}

--- a/invenio_communities/templates/semantic-ui/invenio_notifications/community-membership-request.cancel.jinja
+++ b/invenio_communities/templates/semantic-ui/invenio_notifications/community-membership-request.cancel.jinja
@@ -1,0 +1,60 @@
+{# -*- coding: utf-8 -*-
+
+  Copyright (C) 2026 Northwestern University.
+
+  invenio-communities is free software; you can redistribute it and/or modify it
+  under the terms of the MIT License; see LICENSE file for more details.
+#}
+
+{# Attention: Action-based notifications don't pass `message`, but a separate comment notification is sent so this is fine. #}
+{% set request = notification.context.request %}
+{% set community = request.receiver %}
+{% set community_title = community["metadata"]["title"] %}
+{% set created_by = request.created_by %}
+{% set requester_name = created_by.username or created_by.profile.full_name %}
+{# This email is sent to the community owners/managers so community link used #}
+{% set request_link = invenio_url_for("invenio_app_rdm_requests.community_dashboard_membership_request_view", pid_value=community.slug, request_pid_value=request.id) %}
+{% set account_settings_link = invenio_url_for("invenio_notifications_settings.index") %}
+
+
+{%- block subject -%}
+❌ {{ _("The request from '@{requester_name}' to join the community '{community_title}' was cancelled").format(requester_name=requester_name, community_title=community_title) }}
+{%- endblock subject -%}
+
+
+{%- block html_body -%}
+<table style="font-family:'Lato',Helvetica,Arial,sans-serif;border-spacing:15px">
+  <tr>
+    <td>{{ _("The membership request from '@{requester_name}' to join the community '{community_title}' was cancelled").format(requester_name=requester_name, community_title=community_title) }}.</td>
+  </tr>
+  <tr>
+    <td><a href="{{ request_link }}" class="button">{{ _("Check out the membership request")}}</a></td>
+  </tr>
+  <tr>
+    <td><strong>_</strong></td>
+  </tr>
+  <tr>
+    <td style="font-size:smaller">{{ _("This is an auto-generated message. To manage notifications, visit your")}} <a href="{{ account_settings_link }}">{{ _("account settings")}}</a>.</td>
+  </tr>
+</table>
+{%- endblock html_body %}
+
+
+{%- block plain_body -%}
+{{ _("The membership request from '@{requester_name}' to join the community '{community_title}' was cancelled").format(requester_name=requester_name, community_title=community_title) }}.
+
+{{ _("Check out the membership request") }}: {{ request_link }} .
+
+{{ _("This is an auto-generated message. To manage notifications, visit your account settings") }}: {{ account_settings_link }} .
+{%- endblock plain_body %}
+
+
+{# Markdown for Slack/Mattermost/chat #}
+{%- block md_body -%}
+{{ _("The membership request from *@{requester_name}* to join the community *{community_title}* was cancelled").format(requester_name=requester_name, community_title=community_title) }}.
+
+[{{ _("Check out the membership request") }}]({{ request_link }})
+
+{{ _("This is an auto-generated message. To manage notifications, visit your [account
+settings]({account_settings_link})").format(account_settings_link=account_settings_link) }}.
+{%- endblock md_body %}

--- a/invenio_communities/templates/semantic-ui/invenio_notifications/community-membership-request.decline.jinja
+++ b/invenio_communities/templates/semantic-ui/invenio_notifications/community-membership-request.decline.jinja
@@ -1,0 +1,60 @@
+{# -*- coding: utf-8 -*-
+
+Copyright (C) 2026 Northwestern University.
+
+invenio-communities is free software; you can redistribute it and/or modify it
+under the terms of the MIT License; see LICENSE file for more details.
+#}
+
+{# Attention: Action-based notifications don't pass `message`, but a separate comment notification is sent so this is fine. #}
+{% set request = notification.context.request %}
+{% set community = request.receiver %}
+{% set community_title = community["metadata"]["title"] %}
+{# This email is sent to the original requester so user dashboard link is used #}
+{% set request_link = invenio_url_for("invenio_app_rdm_requests.user_dashboard_request_view", request_pid_value=request.id) %}
+{% set account_settings_link = invenio_url_for("invenio_notifications_settings.index") %}
+
+
+{%- block subject -%}
+⛔️ {{ _("The request to join the community '{community_title}' was declined").format(community_title=community_title) }}
+{%- endblock subject -%}
+
+
+{%- block html_body -%}
+<table style="font-family:'Lato',Helvetica,Arial,sans-serif;border-spacing:15px">
+  <tr>
+    <td>
+      {# No clear reason to provide the exact user who declined and this may create undue friction #}
+      {{ _("The request to join the community '{community_title}' was declined").format(community_title=community_title) }}.
+    </td>
+  </tr>
+  <tr>
+    <td><a href="{{ request_link }}" class="button">{{ _("Check out the membership request")}}</a></td>
+  </tr>
+  <tr>
+      <td><strong>_</strong></td>
+  </tr>
+  <tr>
+      <td style="font-size:smaller">{{ _("This is an auto-generated message. To manage notifications, visit your") }} <a href="{{ account_settings_link }}">{{ _("account settings") }}</a>.</td>
+  </tr>
+</table>
+{%- endblock html_body %}
+
+
+{%- block plain_body -%}
+{{ _("The request to join the community '{community_title}' was declined").format(community_title=community_title) }}.
+
+{{ _("Check out the membership request") }}: {{ request_link }} .
+
+{{ _("This is an auto-generated message. To manage notifications, visit your account settings") }}: {{ account_settings_link }} .
+{%- endblock plain_body %}
+
+
+{# Markdown for Slack/Mattermost/chat #}
+{%- block md_body -%}
+{{ _("The request to join the community *{community_title}* was declined").format(community_title=community_title) }}.
+
+[{{ _("Check out the membership request") }}]({{ request_link }})
+
+{{ _("This is an auto-generated message. To manage notifications, visit your [account settings]({account_settings_link})").format(account_settings_link=account_settings_link) }}.
+{%- endblock md_body %}

--- a/invenio_communities/templates/semantic-ui/invenio_notifications/community-membership-request.expire.jinja
+++ b/invenio_communities/templates/semantic-ui/invenio_notifications/community-membership-request.expire.jinja
@@ -1,0 +1,79 @@
+{# -*- coding: utf-8 -*-
+
+  Copyright (C) 2026 Northwestern University.
+
+  invenio-communities is free software; you can redistribute it and/or modify it
+  under the terms of the MIT License; see LICENSE file for more details.
+#}
+
+{% set request = notification.context.request %}
+{% set requester = request.created_by %}
+{% set recipient_is_requester = recipient.data.id == requester.id  %}
+{% set community = request.receiver %}
+{% set community_title = community["metadata"]["title"] %}
+{% set requester_name = requester.username or requester.profile.full_name %}
+{% set request_link = (
+  invenio_url_for("invenio_app_rdm_requests.user_dashboard_request_view", request_pid_value=request.id)
+  if recipient_is_requester else
+  invenio_url_for("invenio_app_rdm_requests.community_dashboard_membership_request_view", pid_value=community.slug, request_pid_value=request.id)
+) %}
+{% set account_settings_link = invenio_url_for("invenio_notifications_settings.index") %}
+
+
+{%- block subject -%}
+{%- if recipient_is_requester -%}
+⌛️ {{ _("Your request to join the community '{community_title}' expired").format(community_title=community_title) }}
+{%- else -%}
+⌛️ {{ _("The request from '@{user_name}' to join the community '{community_title}' expired").format(user_name=requester_name, community_title=community_title) }}
+{%- endif -%}
+{%- endblock subject -%}
+
+{%- block html_body -%}
+<table style="font-family:'Lato',Helvetica,Arial,sans-serif;border-spacing:15px">
+  <tr>
+    <td>
+      {%- if recipient_is_requester -%}
+      {{ _("Your request to join the community '{community_title}' expired").format(community_title=community_title) }}.
+      {%- else -%}
+      {{ _("The request from '@{user_name}' to join the community '{community_title}' expired").format(user_name=requester_name, community_title=community_title) }}.
+      {%- endif -%}
+    </td>
+  </tr>
+  <tr>
+    <td><a href="{{ request_link }}" class="button">{{ _("Check out the membership request") }}</a></td>
+  </tr>
+  <tr>
+    <td><strong>_</strong></td>
+  </tr>
+  <tr>
+    <td style="font-size:smaller">{{ _("This is an auto-generated message. To manage notifications, visit your")}} <a href="{{ account_settings_link }}">{{ _("account settings")}}</a>.</td>
+  </tr>
+</table>
+{%- endblock html_body %}
+
+
+{%- block plain_body -%}
+{%- if recipient_is_requester -%}
+{{ _("Your request to join the community '{community_title}' expired").format(community_title=community_title) }}.
+{%- else -%}
+{{ _("The request from '@{user_name}' to join the community '{community_title}' expired").format(user_name=requester_name, community_title=community_title) }}.
+{%- endif %}
+
+{{ _("Check out the membership request") }}: {{ request_link }} .
+
+{{ _("This is an auto-generated message. To manage notifications, visit your account settings") }}: {{ account_settings_link }} .
+{%- endblock plain_body %}
+
+
+{# Markdown for Slack/Mattermost/chat #}
+{%- block md_body -%}
+{%- if recipient_is_requester -%}
+{{ _("Your request to join the community *{community_title}* expired").format(community_title=community_title) }}.
+{%- else -%}
+{{ _("The request from *@{user_name}* to join the community *{community_title}* expired").format(user_name=requester_name, community_title=community_title) }}.
+{%- endif %}
+
+[{{ _("Check out the membership request") }}]({{ request_link }})
+
+{{ _("This is an auto-generated message. To manage notifications, visit your [account settings]({account_settings_link})").format(account_settings_link=account_settings_link) }}.
+{%- endblock md_body %}

--- a/invenio_communities/templates/semantic-ui/invenio_notifications/community-membership-request.submit.jinja
+++ b/invenio_communities/templates/semantic-ui/invenio_notifications/community-membership-request.submit.jinja
@@ -1,0 +1,71 @@
+{# -*- coding: utf-8 -*-
+
+  Copyright (C) 2026 Northwestern University.
+
+  invenio-communities is free software; you can redistribute it and/or modify it
+  under the terms of the MIT License; see LICENSE file for more details.
+#}
+
+{% set request = notification.context.request %}
+{% set community = request.receiver %}
+{% set community_title = community["metadata"]["title"] %}
+{% set created_by = request.created_by %}
+{% set message = notification.context.message | safe if notification.context.message else '' %}
+{% set role = notification.context.role %}
+{% set user_name = created_by.username or created_by.profile.full_name %}
+{# This email is sent to the community owners/managers so community link used #}
+{% set request_link = invenio_url_for("invenio_app_rdm_requests.community_dashboard_membership_request_view", pid_value=community.slug, request_pid_value=request.id) %}
+{% set account_settings_link = invenio_url_for("invenio_notifications_settings.index") %}
+
+
+{%- block subject -%}
+📬 {{ _("New request from '@{user_name}' to join the community '{community_title}'").format(community_title=community_title, user_name=user_name) }}
+{%- endblock subject -%}
+
+
+{%- block html_body -%}
+<table style="font-family:'Lato',Helvetica,Arial,sans-serif;border-spacing:15px">
+  <tr>
+    <td>{{ _("'@{user_name}' wants to join the community '{community_title}' as '{role}'").format(user_name=user_name, community_title=community_title, role=role) }}
+      {% if message %}{{ _(" with the following message:") }}{% endif %}
+    </td>
+  </tr>
+  <tr>
+    {% if message %}
+    <td><em>"{{ message }}"</em></td>
+    {% endif %}
+  </tr>
+  <tr>
+    <td><a href="{{ request_link }}" class="button">{{ _("Check out the membership request") }}</a></td>
+  </tr>
+  <tr>
+    <td><strong>_</strong></td>
+  </tr>
+  <tr>
+    <td style="font-size:smaller">{{ _("This is an auto-generated message. To manage notifications, visit your") }} <a href="{{ account_settings_link }}">{{ _("account settings")}}</a>.</td>
+  </tr>
+</table>
+{%- endblock html_body %}
+
+
+{%- block plain_body -%}
+{{ _("'@{user_name}' wants to join the community '{community_title}' as '{role}'").format(user_name=user_name, community_title=community_title, role=role) }}
+{% if message %}{{ _(" with the following message:") }} "{{ message }}"{% endif %}
+
+{{ _("Check out the membership request") }}: {{ request_link }} .
+
+{{ _("This is an auto-generated message. To manage notifications, visit your account settings") }}: {{ account_settings_link }} .
+{%- endblock plain_body %}
+
+
+{# Markdown for Slack/Mattermost/chat #}
+{%- block md_body -%}
+{{ _("*@{user_name}* wants to join the community *{community_title}* as *{role}*").format(user_name=user_name, community_title=community_title, role=role) }}
+{% if message %}{{ _("with the following message:") }} {{ message }}{% endif %}
+
+[{{ _("Check out the membership request") }}]({{ request_link }})
+
+{{ _("This is an auto-generated message. To manage notifications, visit your [account
+settings]({account_settings_link})").format(account_settings_link=account_settings_link) }}.
+
+{%- endblock md_body %}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,8 +46,8 @@ from invenio_communities.notifications.builders import (
     CommunityMembershipRequestAcceptedNotificationBuilder,
     CommunityMembershipRequestCancelledNotificationBuilder,
     CommunityMembershipRequestDeclinedNotificationBuilder,
-    CommunityMembershipRequestSubmittedNotificationBuilder,
     CommunityMembershipRequestExpiredNotificationBuilder,
+    CommunityMembershipRequestSubmittedNotificationBuilder,
 )
 from invenio_communities.proxies import current_communities
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,6 +43,11 @@ from invenio_communities.notifications.builders import (
     CommunityInvitationDeclineNotificationBuilder,
     CommunityInvitationExpireNotificationBuilder,
     CommunityInvitationSubmittedNotificationBuilder,
+    CommunityMembershipRequestAcceptedNotificationBuilder,
+    CommunityMembershipRequestCancelledNotificationBuilder,
+    CommunityMembershipRequestDeclinedNotificationBuilder,
+    CommunityMembershipRequestSubmittedNotificationBuilder,
+    CommunityMembershipRequestExpiredNotificationBuilder,
 )
 from invenio_communities.proxies import current_communities
 
@@ -124,6 +129,11 @@ def app_config(app_config):
         CommunityInvitationDeclineNotificationBuilder.type: CommunityInvitationDeclineNotificationBuilder,
         CommunityInvitationExpireNotificationBuilder.type: CommunityInvitationExpireNotificationBuilder,
         CommunityInvitationSubmittedNotificationBuilder.type: CommunityInvitationSubmittedNotificationBuilder,
+        CommunityMembershipRequestAcceptedNotificationBuilder.type: CommunityMembershipRequestAcceptedNotificationBuilder,
+        CommunityMembershipRequestCancelledNotificationBuilder.type: CommunityMembershipRequestCancelledNotificationBuilder,
+        CommunityMembershipRequestDeclinedNotificationBuilder.type: CommunityMembershipRequestDeclinedNotificationBuilder,
+        CommunityMembershipRequestExpiredNotificationBuilder.type: CommunityMembershipRequestExpiredNotificationBuilder,
+        CommunityMembershipRequestSubmittedNotificationBuilder.type: CommunityMembershipRequestSubmittedNotificationBuilder,
     }
 
     # Specifying default resolvers. Will only be used in specific test cases.
@@ -619,6 +629,35 @@ def community_type_record(
 
     Vocabulary.index.refresh()  # Refresh the index
     return records_list
+
+
+@pytest.fixture(scope="function")
+def create_member(member_service, db):
+    """Factory fixture to create a community member."""
+
+    def _create_member(
+        community_id, user_id, role="reader", visible=False, active=True
+    ):
+        m = Member.create(
+            {},
+            community_id=community_id,
+            user_id=user_id,
+            role=role,
+            visible=visible,
+            active=active,
+        )
+        member_service.indexer.index(m)
+        Member.index.refresh()
+
+        # reindex user to make sure the user service is up-to-date
+        current_users_service.indexer.process_bulk_queue()
+        current_users_service.record_cls.index.refresh()
+
+        db.session.commit()
+
+        return m
+
+    return _create_member
 
 
 @pytest.fixture(scope="function")

--- a/tests/members/conftest.py
+++ b/tests/members/conftest.py
@@ -102,8 +102,10 @@ def membership_request(
     """A membership request."""
     user = create_user()
     data = {"message": "Can I join the club?"}
-    return member_service.request_membership(
+    request_result = member_service.request_membership(
         user.identity,
         community_open_to_membership_requests._record.id,
         data,
     )
+    Member.index.refresh()
+    return request_result

--- a/tests/members/test_members_notifications.py
+++ b/tests/members/test_members_notifications.py
@@ -72,43 +72,36 @@ def check_msg_content_for(message, list_of_required_content):
             assert required_content in content
 
 
+def get_msg_to_email(outbox, email):
+    """Get outbox message sent to email."""
+    msg = next((msg for msg in outbox if email in msg.send_to), None)
+    assert msg
+    return msg
+
+
 #
 # invenio-notification testcases
 #
 def test_community_invitation_submit_notification(
-    member_service,
-    requests_service,
-    community,
-    owner,
-    new_user,
-    db,
-    monkeypatch,
     app,
     clean_index,
+    community,
+    db,
+    mail_ext,
+    member_service,
+    mock_build_of_notification_builder,
+    new_user,
+    owner,
+    requests_service,
 ):
     """Test notifcation being built on community invitation submit."""
 
-    original_builder = CommunityInvitationSubmittedNotificationBuilder
-
     # mock build to observe calls
-    mock_build = MagicMock()
-    mock_build.side_effect = original_builder.build
-    monkeypatch.setattr(original_builder, "build", mock_build)
-    # setting specific builder for test case
-    monkeypatch.setattr(
-        current_notifications_manager,
-        "builders",
-        {
-            **current_notifications_manager.builders,
-            original_builder.type: original_builder,
-        },
+    mock_build = mock_build_of_notification_builder(
+        CommunityInvitationSubmittedNotificationBuilder
     )
-    assert not mock_build.called
 
-    mail = app.extensions.get("mail")
-    assert mail
-
-    with mail.record_messages() as outbox:
+    with mail_ext.record_messages() as outbox:
         # Validate that email was sent
         role = "reader"
         message = "<p>invitation message</p>"
@@ -128,8 +121,8 @@ def test_community_invitation_submit_notification(
         assert mock_build.called
         assert len(outbox) == 1
         html = outbox[0].html
-        # TODO: update to `req["links"]["self_html"]` when addressing https://github.com/inveniosoftware/invenio-rdm-records/issues/1327
-        assert "/me/requests/{}".format(inv["request"]["id"]) in html
+        request_id = inv["request"]["id"]
+        assert f"/me/requests/{request_id}" in html
         assert "/account/settings/notifications" in html
         # role titles will be capitalized
         assert role.capitalize() in html
@@ -138,8 +131,8 @@ def test_community_invitation_submit_notification(
         assert community["metadata"]["title"] in html
 
     # decline to reset
-    requests_service.execute_action(new_user.identity, inv["request"]["id"], "decline")
-    with mail.record_messages() as outbox:
+    requests_service.execute_action(new_user.identity, request_id, "decline")
+    with mail_ext.record_messages() as outbox:
         data = {
             "members": [{"type": "user", "id": str(new_user.id)}],
             "role": role,
@@ -151,43 +144,25 @@ def test_community_invitation_submit_notification(
         assert res["hits"]["total"] == 2
         inv = res["hits"]["hits"][1]
 
-        # check notification is build on submit
-        assert mock_build.called
-        assert len(outbox) == 1
-        html = outbox[0].html
-        # TODO: update to `req["links"]["self_html"]` when addressing https://github.com/inveniosoftware/invenio-rdm-records/issues/1327
-        assert "/me/requests/{}".format(inv["request"]["id"]) in html
-        # role titles will be capitalized
-        assert role.capitalize() in html
-        assert "You have been invited to join" in html
-        assert "with the following message:" not in html
-        assert community["metadata"]["title"] in html
-
 
 def test_community_invitation_accept_notification(
-    member_service,
-    requests_service,
-    community,
-    new_user,
-    db,
-    monkeypatch,
     app,
-    members,
     clean_index,
+    community,
+    db,
+    mail_ext,
+    member_service,
+    members,
+    mock_build_of_notification_builder,
+    new_user,
+    requests_service,
 ):
     """Test notifcation sent on community invitation accept."""
 
-    original_builder = CommunityInvitationAcceptNotificationBuilder
-
     owner = members["owner"]
-    # mock build to observe calls
-    mock_build = MagicMock()
-    mock_build.side_effect = original_builder.build
-    monkeypatch.setattr(original_builder, "build", mock_build)
-    assert not mock_build.called
-
-    mail = app.extensions.get("mail")
-    assert mail
+    mock_build = mock_build_of_notification_builder(
+        CommunityInvitationAcceptNotificationBuilder
+    )
 
     role = "reader"
     data = {
@@ -198,18 +173,18 @@ def test_community_invitation_accept_notification(
     res = member_service.search_invitations(owner.identity, community.id).to_dict()
     assert res["hits"]["total"] == 1
     inv = res["hits"]["hits"][0]
-    with mail.record_messages() as outbox:
+
+    with mail_ext.record_messages() as outbox:
+        request_id = inv["request"]["id"]
         # Validate that email was sent
-        requests_service.execute_action(
-            new_user.identity, inv["request"]["id"], "accept"
-        )
+        requests_service.execute_action(new_user.identity, request_id, "accept")
         # check notification is build on submit
         assert mock_build.called
         # community owner, manager get notified
         assert len(outbox) == 2
         html = outbox[0].html
-        # TODO: update to `req["links"]["self_html"]` when addressing https://github.com/inveniosoftware/invenio-rdm-records/issues/1327
-        assert "/me/requests/{}".format(inv["request"]["id"]) in html
+        community_slug = community._record.slug
+        assert f"/communities/{community_slug}/requests/{request_id}" in html
         # role titles will be capitalized
         assert (
             "'@{who}' accepted the invitation to join your community '{title}'".format(
@@ -222,28 +197,23 @@ def test_community_invitation_accept_notification(
 
 
 def test_community_invitation_cancel_notification(
-    member_service,
-    requests_service,
-    community,
-    owner,
-    new_user,
-    db,
-    monkeypatch,
     app,
     clean_index,
+    community,
+    db,
+    mail_ext,
+    member_service,
+    mock_build_of_notification_builder,
+    new_user,
+    owner,
+    requests_service,
 ):
     """Test notifcation sent on community invitation cancel."""
 
-    original_builder = CommunityInvitationCancelNotificationBuilder
-
     # mock build to observe calls
-    mock_build = MagicMock()
-    mock_build.side_effect = original_builder.build
-    monkeypatch.setattr(original_builder, "build", mock_build)
-    assert not mock_build.called
-
-    mail = app.extensions.get("mail")
-    assert mail
+    mock_build = mock_build_of_notification_builder(
+        CommunityInvitationCancelNotificationBuilder
+    )
 
     role = "reader"
     data = {
@@ -255,16 +225,17 @@ def test_community_invitation_cancel_notification(
     res = member_service.search_invitations(owner.identity, community.id).to_dict()
     assert res["hits"]["total"] == 1
     inv = res["hits"]["hits"][0]
-    with mail.record_messages() as outbox:
+
+    with mail_ext.record_messages() as outbox:
+        request_id = inv["request"]["id"]
         # Validate that email was sent
-        requests_service.execute_action(owner.identity, inv["request"]["id"], "cancel")
+        requests_service.execute_action(owner.identity, request_id, "cancel")
         # check notification is build on submit
         assert mock_build.called
         # invited user gets notified
         assert len(outbox) == 1
         html = outbox[0].html
-        # TODO: update to `req["links"]["self_html"]` when addressing https://github.com/inveniosoftware/invenio-rdm-records/issues/1327
-        assert "/me/requests/{}".format(inv["request"]["id"]) in html
+        assert "/me/requests/{}".format(request_id) in html
         # role titles will be capitalized
         assert (
             "The invitation for '@{who}' to join community '{title}' was cancelled".format(
@@ -277,29 +248,24 @@ def test_community_invitation_cancel_notification(
 
 
 def test_community_invitation_decline_notification(
-    member_service,
-    requests_service,
-    community,
-    new_user,
-    db,
-    monkeypatch,
     app,
-    members,
     clean_index,
+    community,
+    db,
+    mail_ext,
+    member_service,
+    members,
+    mock_build_of_notification_builder,
+    new_user,
+    requests_service,
 ):
     """Test notifcation sent on community invitation decline."""
 
     owner = members["owner"]
-    original_builder = CommunityInvitationDeclineNotificationBuilder
-
     # mock build to observe calls
-    mock_build = MagicMock()
-    mock_build.side_effect = original_builder.build
-    monkeypatch.setattr(original_builder, "build", mock_build)
-    assert not mock_build.called
-
-    mail = app.extensions.get("mail")
-    assert mail
+    mock_build = mock_build_of_notification_builder(
+        CommunityInvitationDeclineNotificationBuilder
+    )
 
     role = "reader"
     data = {
@@ -310,19 +276,19 @@ def test_community_invitation_decline_notification(
     res = member_service.search_invitations(owner.identity, community.id).to_dict()
     assert res["hits"]["total"] == 1
     inv = res["hits"]["hits"][0]
-    with mail.record_messages() as outbox:
+
+    with mail_ext.record_messages() as outbox:
+        request_id = inv["request"]["id"]
         # Validate that email was sent
         # Added resp
-        resp = requests_service.execute_action(
-            new_user.identity, inv["request"]["id"], "decline"
-        )
+        resp = requests_service.execute_action(new_user.identity, request_id, "decline")
         # check notification is build on submit
         assert mock_build.called
         # community owner, manager get notified
         assert len(outbox) == 2
         html = outbox[0].html
-        # TODO: update to `req["links"]["self_html"]` when addressing https://github.com/inveniosoftware/invenio-rdm-records/issues/1327
-        assert "/me/requests/{}".format(inv["request"]["id"]) in html
+        community_slug = community._record.slug
+        assert f"/communities/{community_slug}/requests/{request_id}" in html
         # role titles will be capitalized
         assert (
             "'@{who}' declined the invitation to join your community '{title}'".format(
@@ -335,29 +301,24 @@ def test_community_invitation_decline_notification(
 
 
 def test_community_invitation_expire_notification(
-    member_service,
-    requests_service,
-    community,
-    new_user,
-    db,
-    monkeypatch,
     app,
-    members,
     clean_index,
+    community,
+    db,
+    mail_ext,
+    member_service,
+    members,
+    mock_build_of_notification_builder,
+    new_user,
+    requests_service,
 ):
     """Test notifcation sent on community invitation decline."""
 
     owner = members["owner"]
-    original_builder = CommunityInvitationExpireNotificationBuilder
-
     # mock build to observe calls
-    mock_build = MagicMock()
-    mock_build.side_effect = original_builder.build
-    monkeypatch.setattr(original_builder, "build", mock_build)
-    assert not mock_build.called
-
-    mail = app.extensions.get("mail")
-    assert mail
+    mock_build = mock_build_of_notification_builder(
+        CommunityInvitationExpireNotificationBuilder
+    )
 
     role = "reader"
     data = {
@@ -368,29 +329,42 @@ def test_community_invitation_expire_notification(
     res = member_service.search_invitations(owner.identity, community.id).to_dict()
     assert res["hits"]["total"] == 1
     inv = res["hits"]["hits"][0]
-    with mail.record_messages() as outbox:
+
+    with mail_ext.record_messages() as outbox:
+        request_id = inv["request"]["id"]
         # Validate that email was sent
-        requests_service.execute_action(system_identity, inv["request"]["id"], "expire")
+        requests_service.execute_action(system_identity, request_id, "expire")
 
         # check notification is build on submit
         assert mock_build.called
         # community owner, manager and invited user get notified
-        # TODO: Replace with equivalent
         assert len(outbox) == 3
-        html = outbox[0].html
-        # TODO: update to `req["links"]["self_html"]` when addressing https://github.com/inveniosoftware/invenio-rdm-records/issues/1327
-        assert "/me/requests/{}".format(inv["request"]["id"]) in html
-        # role titles will be capitalized
-        assert (
-            "The invitation for '@{who}' to join community '{title}' has expired.".format(
-                who=new_user.user.username
-                or new_user.user.user_profile.get("full_name"),
-                title=community["metadata"]["title"],
-            )
-            in html
+        all_send_to = reduce(lambda s, m: m.send_to | s, outbox, set())
+        manager = members["manager"]
+        assert {new_user.email, manager.email, owner.email} == all_send_to
+
+        # Relevant kinds of messages to test
+        msg_to_manager = get_msg_to_email(outbox, manager.email)
+        msg_to_invitee = get_msg_to_email(outbox, new_user.email)
+
+        who = new_user.user.username or new_user.user.user_profile.get("full_name")
+        title = community["metadata"]["title"]
+        expiration_sentence = (
+            f"The invitation for '@{who}' to join community '{title}' expired."
         )
 
+        # Check manager content for key information
+        community_slug = community._record.slug
+        link = f"/communities/{community_slug}/requests/{request_id}"
+        check_msg_content_for(msg_to_manager, [expiration_sentence, link])
+        # Check invitee content for key information
+        link = f"/me/requests/{request_id}"
+        check_msg_content_for(msg_to_invitee, [expiration_sentence, link])
 
+
+#
+# membership request notification testcases
+#
 def test_request_membership_emits_notification(
     clean_index,  # instead of search_clear because module fixtures present
     community_open_to_membership_requests,
@@ -631,16 +605,9 @@ def test_expire_membership_request_emits_notification(
         requests_service.execute_action(system_identity, request_result.id, "expire")
 
         assert mock_build.called
-        # breakpoint()
         assert 3 == len(outbox)
         all_send_to = reduce(lambda s, m: m.send_to | s, outbox, set())
         assert {requester.user.email, manager_user.email, owner.email} == all_send_to
-
-        def get_msg_to_email(outbox, email):
-            """Get outbox message sent to email."""
-            msg = next((msg for msg in outbox if email in msg.send_to), None)
-            assert msg
-            return msg
 
         msg_to_manager = get_msg_to_email(outbox, manager_user.email)
         msg_to_requester = get_msg_to_email(outbox, requester.user.email)

--- a/tests/members/test_members_notifications.py
+++ b/tests/members/test_members_notifications.py
@@ -6,8 +6,10 @@
 # Invenio-Communities is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more details.
 
+from functools import reduce
 from unittest.mock import MagicMock
 
+import pytest
 from invenio_access.permissions import system_identity
 from invenio_notifications.proxies import current_notifications_manager
 
@@ -17,7 +19,57 @@ from invenio_communities.notifications.builders import (
     CommunityInvitationDeclineNotificationBuilder,
     CommunityInvitationExpireNotificationBuilder,
     CommunityInvitationSubmittedNotificationBuilder,
+    CommunityMembershipRequestAcceptedNotificationBuilder,
+    CommunityMembershipRequestCancelledNotificationBuilder,
+    CommunityMembershipRequestDeclinedNotificationBuilder,
+    CommunityMembershipRequestExpiredNotificationBuilder,
+    CommunityMembershipRequestSubmittedNotificationBuilder,
 )
+
+
+@pytest.fixture(scope="module")
+def mail_ext(app):
+    """Flask-Mail extension."""
+    mail = app.extensions.get("mail")
+    assert mail
+    return mail
+
+
+@pytest.fixture()
+def mock_build_of_notification_builder(monkeypatch):
+    """Factory fixture for setting up the builder under test and getting mock."""
+
+    def _inner(builder_cls):
+        """Do actual work."""
+        # mock build to observe calls
+        mock_build = MagicMock(side_effect=builder_cls.build)
+        monkeypatch.setattr(builder_cls, "build", mock_build)
+        # setting specific builder for test case
+        monkeypatch.setattr(
+            current_notifications_manager,
+            "builders",
+            {
+                **current_notifications_manager.builders,
+                builder_cls.type: builder_cls,
+            },
+        )
+        assert not mock_build.called
+        return mock_build
+
+    return _inner
+
+
+def check_msg_subject_for(message, list_of_required_content):
+    """Check mail subject for content."""
+    for required in list_of_required_content:
+        assert required in message.subject
+
+
+def check_msg_content_for(message, list_of_required_content):
+    """Check message body (incl. html) for content."""
+    for required_content in list_of_required_content:
+        for content in [message.body, message.html]:
+            assert required_content in content
 
 
 #
@@ -337,3 +389,278 @@ def test_community_invitation_expire_notification(
             )
             in html
         )
+
+
+def test_request_membership_emits_notification(
+    clean_index,  # instead of search_clear because module fixtures present
+    community_open_to_membership_requests,
+    create_member,
+    create_user,
+    db,
+    mail_ext,
+    member_service,
+    mock_build_of_notification_builder,
+):
+    community = community_open_to_membership_requests
+    mock_build = mock_build_of_notification_builder(
+        CommunityMembershipRequestSubmittedNotificationBuilder
+    )
+
+    requester = create_user({"email": "requester@example.org", "username": "requester"})
+    manager_user = create_user(
+        {"email": "manager@example.org", "username": "manager_other"}
+    )
+    manager_member = create_member(
+        community_id=community.id, user_id=manager_user.id, role="manager"
+    )
+
+    # Validate that notification email was sent
+    with mail_ext.record_messages() as outbox:
+        core_message = "membership request message"
+        message = f"<p>{core_message}</p>"
+        request_result = member_service.request_membership(
+            requester.identity, community.id, {"message": message}
+        )
+
+        assert mock_build.called
+        assert 2 == len(outbox)
+        all_send_to = reduce(lambda s, m: m.send_to | s, outbox, set())
+        assert {"manager@example.org", "owner@owner.org"} == all_send_to
+        request_id = request_result.id
+        community_slug = community._record.slug
+        requester_name = requester.user.username or requester.user.user_profile.get(
+            "full_name"
+        )
+        community_title = community["metadata"]["title"]
+        role = "reader"
+        # Since receivers of the request are community owners + managers
+        # the link in the request is to the community request page
+        link = f"/communities/{community_slug}/membership-requests/{request_id}"
+        # Same content across all messages so just testing first
+        # Check subject
+        check_msg_subject_for(outbox[0], [requester_name, community_title])
+        # Check content
+        check_msg_content_for(outbox[0], [requester_name, community_title, role, link])
+        # just checking html tags of message stripped in plain text
+        # won't do for other tests
+        assert core_message in outbox[0].body
+        assert message not in outbox[0].body
+        assert message in outbox[0].html
+
+
+def test_cancel_membership_request_emits_notification(
+    clean_index,  # instead of search_clear because module fixtures present
+    community_open_to_membership_requests,
+    create_member,
+    create_user,
+    db,
+    mail_ext,
+    member_service,
+    mock_build_of_notification_builder,
+    owner,
+    requests_service,
+):
+    community = community_open_to_membership_requests
+    mock_build = mock_build_of_notification_builder(
+        CommunityMembershipRequestCancelledNotificationBuilder
+    )
+    requester = create_user({"email": "requester@example.org", "username": "requester"})
+    manager_user = create_user(
+        {"email": "manager@example.org", "username": "manager_other"}
+    )
+    manager_member = create_member(
+        community_id=community.id, user_id=manager_user.id, role="manager"
+    )
+    message = "<p>membership request message</p>"
+    request_result = member_service.request_membership(
+        requester.identity, community.id, {"message": message}
+    )
+
+    # Validate that email was sent
+    with mail_ext.record_messages() as outbox:
+        requests_service.execute_action(requester.identity, request_result.id, "cancel")
+
+        assert mock_build.called
+        assert 2 == len(outbox)
+        all_send_to = reduce(lambda s, m: m.send_to | s, outbox, set())
+        assert {manager_user.email, owner.email} == all_send_to
+        requester_name = requester.user.username or requester.user.user_profile.get(
+            "full_name"
+        )
+        community_title = community["metadata"]["title"]
+        community_slug = community._record.slug
+        request_id = request_result.id
+        # Since receivers of the request are community owners + managers
+        # the link in the request is to the community request page
+        link = f"/communities/{community_slug}/membership-requests/{request_id}"
+        # Same content across all messages so just testing first
+        # Check subject for key information
+        check_msg_subject_for(outbox[0], [requester_name, community_title])
+        # Check content for key information
+        check_msg_content_for(outbox[0], [requester_name, community_title, link])
+
+
+def test_decline_membership_request_emits_notification(
+    clean_index,  # instead of search_clear because module fixtures present
+    community_open_to_membership_requests,
+    create_member,
+    create_user,
+    db,
+    mail_ext,
+    member_service,
+    mock_build_of_notification_builder,
+    owner,
+    requests_service,
+):
+    community_result = community_open_to_membership_requests
+    mock_build = mock_build_of_notification_builder(
+        CommunityMembershipRequestDeclinedNotificationBuilder
+    )
+    requester = create_user({"email": "requester@example.org", "username": "requester"})
+    manager_user = create_user(
+        {"email": "manager@example.org", "username": "manager_other"}
+    )
+    manager_member = create_member(
+        community_id=community_result.id, user_id=manager_user.id, role="manager"
+    )
+    message = "<p>membership request message</p>"
+    request_result = member_service.request_membership(
+        requester.identity, community_result.id, {"message": message}
+    )
+
+    # Validate that email was sent
+    with mail_ext.record_messages() as outbox:
+        requests_service.execute_action(
+            manager_user.identity, request_result.id, "decline"
+        )
+
+        assert mock_build.called
+        assert 1 == len(outbox)
+        all_send_to = reduce(lambda s, m: m.send_to | s, outbox, set())
+        assert {requester.user.email} == all_send_to
+
+        community_title = community_result["metadata"]["title"]
+        # Since receiver of the notification is the request's requester
+        # the link in the notification email is to the user dashboard request
+        link = f"/me/requests/{request_result.id}"
+        # Check subject for key information
+        check_msg_subject_for(outbox[0], [community_title])
+        # Check content for key information
+        check_msg_content_for(outbox[0], [community_title, link])
+
+
+def test_accept_membership_request_emits_notification(
+    clean_index,  # instead of search_clear because module fixtures present
+    community_open_to_membership_requests,
+    create_member,
+    create_user,
+    db,
+    mail_ext,
+    member_service,
+    mock_build_of_notification_builder,
+    owner,
+    requests_service,
+):
+    community_result = community_open_to_membership_requests
+    mock_build = mock_build_of_notification_builder(
+        CommunityMembershipRequestAcceptedNotificationBuilder
+    )
+    requester = create_user({"email": "requester@example.org", "username": "requester"})
+    manager_user = create_user(
+        {"email": "manager@example.org", "username": "manager_other"}
+    )
+    manager_member = create_member(
+        community_id=community_result.id, user_id=manager_user.id, role="manager"
+    )
+    message = "<p>membership request message</p>"
+    request_result = member_service.request_membership(
+        requester.identity, community_result.id, {"message": message}
+    )
+
+    # Validate that email was sent
+    with mail_ext.record_messages() as outbox:
+        requests_service.execute_action(
+            manager_user.identity, request_result.id, "accept"
+        )
+
+        assert mock_build.called
+        assert 1 == len(outbox)
+        all_send_to = reduce(lambda s, m: m.send_to | s, outbox, set())
+        assert {requester.user.email} == all_send_to
+
+        community_title = community_result["metadata"]["title"]
+        # Since receiver of the notification is the request's requester
+        # the link in the notification email is to the user dashboard request
+        link = f"/me/requests/{request_result.id}"
+        # Check subject for key information
+        check_msg_subject_for(outbox[0], [community_title])
+        # Check content for key information
+        check_msg_content_for(outbox[0], [community_title, link])
+
+
+def test_expire_membership_request_emits_notification(
+    clean_index,  # instead of search_clear because module fixtures present
+    community_open_to_membership_requests,
+    create_member,
+    create_user,
+    db,
+    mail_ext,
+    member_service,
+    mock_build_of_notification_builder,
+    owner,
+    requests_service,
+):
+    community_result = community_open_to_membership_requests
+    mock_build = mock_build_of_notification_builder(
+        CommunityMembershipRequestExpiredNotificationBuilder
+    )
+    requester = create_user({"email": "requester@example.org", "username": "requester"})
+    manager_user = create_user(
+        {"email": "manager@example.org", "username": "manager_other"}
+    )
+    manager_member = create_member(
+        community_id=community_result.id, user_id=manager_user.id, role="manager"
+    )
+    message = "<p>membership request message</p>"
+    request_result = member_service.request_membership(
+        requester.identity, community_result.id, {"message": message}
+    )
+
+    # Validate that email was sent
+    with mail_ext.record_messages() as outbox:
+        requests_service.execute_action(system_identity, request_result.id, "expire")
+
+        assert mock_build.called
+        # breakpoint()
+        assert 3 == len(outbox)
+        all_send_to = reduce(lambda s, m: m.send_to | s, outbox, set())
+        assert {requester.user.email, manager_user.email, owner.email} == all_send_to
+
+        def get_msg_to_email(outbox, email):
+            """Get outbox message sent to email."""
+            msg = next((msg for msg in outbox if email in msg.send_to), None)
+            assert msg
+            return msg
+
+        msg_to_manager = get_msg_to_email(outbox, manager_user.email)
+        msg_to_requester = get_msg_to_email(outbox, requester.user.email)
+
+        community_title = community_result["metadata"]["title"]
+        community_slug = community_result._record.slug
+        requester_name = requester.user.username or requester.user.user_profile.get(
+            "full_name"
+        )
+
+        # Msg to manager
+        # Check subject for key information
+        check_msg_subject_for(msg_to_manager, [requester_name, community_title])
+        # Check content for key information
+        link = f"/communities/{community_slug}/membership-requests/{request_result.id}"
+        check_msg_content_for(msg_to_manager, [requester_name, community_title, link])
+
+        # Msg to requester
+        # Check subject for key information
+        check_msg_subject_for(msg_to_requester, [community_title])
+        link = f"/me/requests/{request_result.id}"
+        # Check content for key information
+        check_msg_content_for(msg_to_requester, [community_title, link])

--- a/tests/members/test_members_resource.py
+++ b/tests/members/test_members_resource.py
@@ -396,8 +396,8 @@ def test_search_invitations(
     request_id = hit["request"]["id"]
     assert "status" in hit["request"]
     assert "expires_at" in hit["request"]
-    assert "community-invitation" == hit["request"]["type"]
     assert hit["request"]["expires_at"] is not None
+    assert "community-invitation" == hit["request"]["type"]
     # hits > hit > permissions
     assert hit["permissions"]["can_update_role"] is True
     assert hit["permissions"]["can_cancel"] is True
@@ -461,13 +461,13 @@ def test_post_request_membership(
 
 
 def test_get_search_membership_requests(
-    client,
-    headers,
-    community_open_to_membership_requests,
-    owner,
-    membership_request,
-    db,
     clean_index,
+    client,
+    community_open_to_membership_requests,
+    db,
+    headers,
+    membership_request,
+    owner,
 ):
     client = owner.login(client)
     community_id = str(community_open_to_membership_requests._record.id)
@@ -502,11 +502,10 @@ def test_get_search_membership_requests(
     assert "id" in hit["request"]
     assert "status" in hit["request"]
     assert "community-membership-request" == hit["request"]["type"]
+    assert "expires_at" in hit["request"]
+    assert hit["request"]["expires_at"] is not None
     # hits > hit > permissions
     assert hit["permissions"]["can_update_role"] is True
-    # TODO: Test when expiration is implemented
-    # assert "expires_at" in hit["request"]
-    # assert hit["request"]["expires_at"] is not None
     # hits > hit > links
     request_id = hit["request"]["id"]
     expected_links = {

--- a/tests/members/test_members_services.py
+++ b/tests/members/test_members_services.py
@@ -1440,14 +1440,13 @@ def test_expire_membership_request(
     assert 1 == result["hits"]["total"]
     # 2) one membership request
     result = member_service.search_membership_requests(
-        owner.identity, community.id,
+        owner.identity,
+        community.id,
     ).to_dict()
     assert 1 == result["hits"]["total"]
 
     # Expire request
-    requests_service.execute_action(
-        system_identity, membership_request.id, "expire"
-    )
+    requests_service.execute_action(system_identity, membership_request.id, "expire")
     MemberMixin.index.refresh()
 
     # Post-conditions
@@ -1455,7 +1454,7 @@ def test_expire_membership_request(
     res = member_service.search(owner.identity, community.id)
     assert 1 == res.to_dict()["hits"]["total"]
 
-    # 2) 1 member request, the accepted one
+    # 2) 1 member request, the expired one
     result = member_service.search_membership_requests(
         owner.identity, community.id
     ).to_dict()

--- a/tests/members/test_members_services.py
+++ b/tests/members/test_members_services.py
@@ -18,7 +18,7 @@ from invenio_requests.records.api import Request, RequestEvent
 from marshmallow import ValidationError
 
 from invenio_communities.members.errors import AlreadyMemberError, InvalidMemberError
-from invenio_communities.members.records.api import Member
+from invenio_communities.members.records.api import Member, MemberMixin
 from invenio_communities.proxies import current_identities_cache
 
 
@@ -1342,7 +1342,9 @@ def test_decline_membership_request(
     result = member_service.search(owner.identity, community._record.id).to_dict()
     assert result["hits"]["total"] == 1
 
-    requests_service.execute_action(owner.identity, membership_request.id, "decline")
+    requests_service.execute_action(
+        owner.identity, membership_request._record.id, "decline"
+    )
 
     # Only owner in list
     Member.index.refresh()
@@ -1419,6 +1421,48 @@ def test_update_membership_request_role(
     # Case: requester cannot update its role
     with pytest.raises(PermissionDeniedError):
         member_service.update(user.identity, community._record.id, data)
+
+
+def test_expire_membership_request(
+    clean_index,
+    community_open_to_membership_requests,
+    db,
+    member_service,
+    membership_request,
+    owner,
+    requests_service,
+):
+    community = community_open_to_membership_requests
+
+    # Pre-conditions:
+    # 1) only owner
+    result = member_service.search(owner.identity, community.id).to_dict()
+    assert 1 == result["hits"]["total"]
+    # 2) one membership request
+    result = member_service.search_membership_requests(
+        owner.identity, community.id,
+    ).to_dict()
+    assert 1 == result["hits"]["total"]
+
+    # Expire request
+    requests_service.execute_action(
+        system_identity, membership_request.id, "expire"
+    )
+    MemberMixin.index.refresh()
+
+    # Post-conditions
+    # 1) still 1 member, the owner
+    res = member_service.search(owner.identity, community.id)
+    assert 1 == res.to_dict()["hits"]["total"]
+
+    # 2) 1 member request, the accepted one
+    result = member_service.search_membership_requests(
+        owner.identity, community.id
+    ).to_dict()
+    assert 1 == result["hits"]["total"]
+    hit = result["hits"]["hits"][0]
+    assert "expired" == hit["request"]["status"]
+    assert hit["request"]["is_open"] is False
 
 
 #

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -16,6 +16,7 @@ import copy
 
 import pytest
 from flask_principal import Identity
+from invenio_access.permissions import system_identity
 from invenio_requests.services.permissions import (
     PermissionPolicy as RequestPermissionPolicy,
 )
@@ -82,6 +83,13 @@ def test_can_request_membership(
             owner.identity
         )
     )
+    # TODO: Case - config enabled, setting enabled - already pending decision
+    # assert not (
+    #     policy(action="request_membership", record=community_open_record).allows(
+    #         identity_pending
+    #     )
+    # )
+
     # Case - config enabled, setting enabled - authenticated but not member of community
     assert policy(action="request_membership", record=community_open_record).allows(
         identity_authenticated
@@ -236,6 +244,7 @@ def test_can_update_membership_request_role(
         ("expire", "manager", False),
         ("expire", "curator", False),
         ("expire", "requester", False),
+        ("expire", "system", True),
     ],
 )
 def test_can_perform_actions_on_membership_request(
@@ -260,6 +269,8 @@ def test_can_perform_actions_on_membership_request(
     # Identity of actor
     if role == "requester":
         identity_actor = requester_user.identity
+    elif role == "system":
+        identity_actor = system_identity
     else:
         actor_user = create_user({"username": "actor", "email": "actor@example.org"})
         identity_actor = actor_user.identity


### PR DESCRIPTION
This is the last PR in the series of PRs to revive and merge the "Request to join a community as a user" feature (part 6 was merged in part 7). This PR covers:

- expiry
- notifications
- last overall checks/fixes
- addressing https://github.com/inveniosoftware/invenio-rdm-records/issues/1327 for invitations and membership-requests (didn't touch sub-community as only discovered this while writing this summary)
- closes https://github.com/inveniosoftware/invenio-communities/issues/829  
- closes original PR finally: https://github.com/inveniosoftware/invenio-communities/pull/1175

**out-of-scope**: In the future I may submit: 
1) a mechanism to store a "candidate" role on the identity of requesting user to help alleviate DB hits and 
2) notification pills for invitations and membership requests. But for now, this is good enough. 

**Related PRs**
- Draft RFC here: https://github.com/inveniosoftware/rfcs/pull/111 .
- Invenio-app-rdm final integration PR (to merge after this one is released): https://github.com/inveniosoftware/invenio-app-rdm/pull/3450
- Abandonned original PR: https://github.com/inveniosoftware/invenio-communities/pull/1175

**Release comments**
A major bump release commit will be made after this one goes in since at least 1 accumulated breaking change in previous PR and invenio-app-rdm will need this released to import notification builders. 
