### PR TITLE
template: pages: fix missing titles (about and curation policy)

### DIFF
--- a/invenio_communities/templates/semantic-ui/invenio_communities/details/about/index.html
+++ b/invenio_communities/templates/semantic-ui/invenio_communities/details/about/index.html
@@ -9,6 +9,7 @@
 #}
 
 {% extends "invenio_communities/details/base.html" %}
+{%- set title = community_ui["metadata"]["title"] + _(" about") -%}
 {% from "invenio_communities/details/macros/custom_fields.html" import list_vocabulary_values, list_string_values, show_custom_field %}
 {% set active_community_header_menu_item= 'about' %}
 

--- a/invenio_communities/templates/semantic-ui/invenio_communities/details/curation_policy/index.html
+++ b/invenio_communities/templates/semantic-ui/invenio_communities/details/curation_policy/index.html
@@ -9,6 +9,7 @@
 #}
 
 {% extends "invenio_communities/details/base.html" %}
+{%- set title = community_ui["metadata"]["title"] + _(" curation policy") -%}
 {% set active_community_header_menu_item= 'curation_policy' %}
 
 


### PR DESCRIPTION
Discovered that the About and Curation policy pages had missing titles when testing inveniosoftware/invenio-theme#279