### PR TITLE
Add error handler for `StorageError` exceptions

### DIFF
--- a/invenio_communities/communities/resources/config.py
+++ b/invenio_communities/communities/resources/config.py
@@ -11,6 +11,7 @@ from flask_resources import (
     ResponseHandler,
     create_error_handler,
 )
+from invenio_files_rest.errors import StorageError
 from invenio_i18n import lazy_gettext as _
 from invenio_records_resources.resources import RecordResourceConfig
 from invenio_records_resources.resources.records.headers import etag_headers
@@ -70,6 +71,14 @@ community_error_handlers.update(
             lambda e: HTTPJSONException(
                 code=400,
                 description=str(e),
+            )
+        ),
+        StorageError: create_error_handler(
+            lambda e: HTTPJSONException(
+                code=404,
+                # The StorageError class has code 500 baked in, and adds that when
+                # transformed into a string; so we only use `e.description`
+                description=e.description,
             )
         ),
     }


### PR DESCRIPTION
Previously, `StorageError` exceptions (e.g. when a community logo file cannot be found on disk) was unhandled and resulted in a 500 response.
This PR handles this type of exception, and returns a 404 instead.

Related to https://github.com/inveniosoftware/invenio-files-rest/pull/356 where the `StorageError` constructor call was fixed.