### PR TITLE
refactor(date): replace arrow with pendulum

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,6 +114,7 @@ tests = [
   "faker>=2.0.3",
   "invenio-app>=3.0.0,<4.0.0",
   "invenio-db[postgresql,mysql]>=2.2.0,<3.0.0",
+  "pendulum>=3.2.0",
   "pytest-black>=0.6.0",
   "pytest-invenio>=4.0.0,<5.0.0",
   "sphinx>=4.5.0",

--- a/tests/communities/test_services.py
+++ b/tests/communities/test_services.py
@@ -9,7 +9,7 @@ import uuid
 from copy import deepcopy
 from datetime import datetime, timedelta, timezone
 
-import arrow
+import pendulum
 import pytest
 from invenio_access.permissions import system_identity
 from invenio_cache import current_cache
@@ -423,7 +423,10 @@ def test_community_deletion(community_service, users, comm):
     assert tombstone.removal_reason is None
     assert tombstone.note == tombstone_info["note"]
     assert isinstance(tombstone.citation_text, str)
-    assert arrow.get(tombstone.removal_date).date() == datetime.now(timezone.utc).date()
+    assert (
+        pendulum.parse(tombstone.removal_date).date()
+        == datetime.now(timezone.utc).date()
+    )
 
     # mark the community for purge
     community = community_service.mark_community_for_purge(


### PR DESCRIPTION
* pendulum is always timezone-aware with UTC by default
* in some experiments, it has a slightly better performance

Like https://github.com/inveniosoftware/invenio-banners/pull/76